### PR TITLE
Update and fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ omnicorp-scigraph: ontologies-merged.ttl SciGraph
 	rm -rf $@ && cd SciGraph/SciGraph-core &&\
 	mvn exec:java -DXmx8G -Dexec.mainClass="io.scigraph.owlapi.loader.BatchOwlLoader" -Dexec.args="-c ../../scigraph.yaml"
 
-$(OMNICORP):
+$(OMNICORP): SciGraph
 	sbt stage
 
 output: $(OMNICORP) pubmed-annual-baseline omnicorp-scigraph

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: output
 
 clean:
 	sbt clean
-	rm -rf output SciGraph omnicorp-scigraph pubmed-annual-baseline
+	rm -rf output SciGraph omnicorp-scigraph pubmed-annual-baseline robot robot.jar
 
 pubmed-annual-baseline:
 	mkdir -p $@ && cd $@ &&\

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
+# Omnicorp executable path.
 OMNICORP = ./target/universal/stage/bin/omnicorp
+
+# Maximum memory to use.
+MEMORY = 16G
+
+# Number of parallel jobs to start.
+PARALLEL = 4
 
 .PHONY: all
 all: output
@@ -20,15 +27,15 @@ robot: robot.jar
 	curl -L -O https://raw.githubusercontent.com/ontodev/robot/master/bin/robot && chmod +x robot
 
 ontologies-merged.ttl: robot ontologies.ofn
-	ROBOT_JAVA_ARGS=-Xmx8G ./robot merge -i ontologies.ofn -o ontologies-merged.ttl
+	ROBOT_JAVA_ARGS=-Xmx$(MEMORY) ./robot merge -i ontologies.ofn -o ontologies-merged.ttl
 
 omnicorp-scigraph: ontologies-merged.ttl SciGraph
 	rm -rf $@ && cd SciGraph/SciGraph-core &&\
-	MAVEN_OPTS="-Xmx8G" mvn exec:java -Dexec.mainClass="io.scigraph.owlapi.loader.BatchOwlLoader" -Dexec.args="-c ../../scigraph.yaml"
+	MAVEN_OPTS="-Xmx$(MEMORY)" mvn exec:java -Dexec.mainClass="io.scigraph.owlapi.loader.BatchOwlLoader" -Dexec.args="-c ../../scigraph.yaml"
 
 $(OMNICORP): SciGraph
 	sbt stage
 
 output: $(OMNICORP) pubmed-annual-baseline omnicorp-scigraph
 	rm -rf $@ && mkdir -p $@ &&\
-	JAVA_OPTS=-Xmx80G $(OMNICORP) omnicorp-scigraph pubmed-annual-baseline $@ 20
+	JAVA_OPTS="-Xmx$(MEMORY)" $(OMNICORP) omnicorp-scigraph pubmed-annual-baseline $@ $(PARALLEL)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ontologies-merged.ttl: robot ontologies.ofn
 
 omnicorp-scigraph: ontologies-merged.ttl SciGraph
 	rm -rf $@ && cd SciGraph/SciGraph-core &&\
-	mvn exec:java -DXmx8G -Dexec.mainClass="io.scigraph.owlapi.loader.BatchOwlLoader" -Dexec.args="-c ../../scigraph.yaml"
+	MAVEN_OPTS="-Xmx8G" mvn exec:java -Dexec.mainClass="io.scigraph.owlapi.loader.BatchOwlLoader" -Dexec.args="-c ../../scigraph.yaml"
 
 $(OMNICORP): SciGraph
 	sbt stage

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ PARALLEL = 4
 .PHONY: all
 all: output
 
+clean:
+	sbt clean
+	rm -rf output SciGraph omnicorp-scigraph pubmed-annual-baseline
+
 pubmed-annual-baseline:
 	mkdir -p $@ && cd $@ &&\
 	curl --ftp-method singlecwd -O ftp://ftp.ncbi.nlm.nih.gov/pubmed/baseline/pubmed19n0[001-970].xml.gz


### PR DESCRIPTION
This PR makes four changes to the Makefile:
1. The Omnicorp executable can't be created until SciGraph has been locally installed, so I added `SciGraph` to its prerequisites.
2. `MAVEN_OPTS` is used to set the maximum memory for a Maven job rather than `-D`. Fixed.
3. I collected references to maximum memory and number of parallel jobs and put them into variables so they can be tweaked easily.
4. I added a `clean` target to clean up output and intermediate files.