### PR TITLE
Improved .gitignore to ignore input, output, log, robot and Atom files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,18 @@ target
 /omnicorp-scigraph
 /.idea
 ontologies-merged.ttl
+
+# Ignore input and output directories.
+/pubmed-annual-baseline
+/output
+
+# Ignore robot.
+/robot
+/robot.jar
+
+# Ignore log files.
+/pubmed-terms.log
+
+# Ignore Bloop and Metals files used by Atom in providing a Scala IDE.
+.bloop
+.metals


### PR DESCRIPTION
I mainly needed to do this to ignore the Metal/Bloop files that Atom's Scala UI needs, but I also added instructions to ignore the input, output, robot and log files.