### PR TITLE
Reorganized tests and added test for unparsed months

### DIFF
--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -58,7 +58,12 @@ object PubMedArticleWrapper {
         maybeDayOfMonth.map { day =>
           Success(LocalDate.of(year, month, day))
         }.getOrElse(Success(YearMonth.of(year, month)))
-      }.getOrElse(Success(Year.of(year)))
+      }.getOrElse({
+        // What if we have a maybeYear and a maybeDayOfMonth, but no maybeMonth?
+        // That suggests that we didn't read the month correctly!
+        if (maybeYear.isSuccess && maybeDayOfMonth.isSuccess && maybeMonth.isFailure) Failure(new RuntimeException("Could not extract month from node: " + date))
+        else Success(Year.of(year))
+      })
     }.getOrElse(parseMedlineDate(date))
   }
 }

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -6,7 +6,10 @@ import utest._
 
 import scala.xml.XML
 
-object AnnotatorTest extends TestSuite {
+/**
+ * Integration tests of PubmedArticleWrapper.
+ */
+object PubMedArticleWrapperIntegrationTests extends TestSuite {
   val examplesForTests = XML.loadFile(getClass.getResource("/pubmedXML/examplesForTests.xml").getPath)
   val pubmedArticles = examplesForTests \ "PubmedArticle"
 

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -1,0 +1,47 @@
+package org.renci.chemotext
+
+import java.time.{LocalDate, Year, YearMonth}
+
+import utest._
+
+import scala.util.{Success, Failure}
+import scala.xml.XML
+
+/**
+ * Unit tests for the PubMedArticleWrapper class.
+ */
+object PubMedArticleWrapperUnitTests extends TestSuite {
+  val tests = Tests {
+    test("#parseDate") {
+      test("Test processing of valid dates") {
+        val datesTested = Seq(
+          (Year.of(2006),               <PubDate><Year>2006</Year></PubDate>),
+          (YearMonth.of(2006, 10),      <PubDate><Year>2006</Year><Month>Oct</Month></PubDate>),
+          (LocalDate.of(2006, 10, 21),  <PubDate><Year>2006</Year><Day>21</Day><Month>Oct</Month></PubDate>),
+          (Year.of(1998),               <PubDate><MedlineDate>1998 Dec-1999 Jan</MedlineDate></PubDate>)
+        )
+
+        datesTested.foreach({ case (expected, xmlNode) =>
+          assert(PubMedArticleWrapper.parseDate(xmlNode) == Success(expected))
+        })
+      }
+      test("Test processing of invalid dates") {
+        assert(
+          (intercept[IllegalArgumentException] {
+            PubMedArticleWrapper.parseDate(<PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>).get
+          }).getMessage == "Could not parse XML node as date: <PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>"
+        )
+        assert(
+          (intercept[IllegalArgumentException] {
+            PubMedArticleWrapper.parseDate(<PubDate></PubDate>).get
+          }).getMessage == "Could not parse XML node as date: <PubDate></PubDate>"
+        )
+        assert(
+          (intercept[RuntimeException] {
+            PubMedArticleWrapper.parseDate(<PubDate><Year>2019</Year><Day>12</Day></PubDate>).get
+          }).getMessage == "Could not extract month from node: <PubDate><Year>2019</Year><Day>12</Day></PubDate>"
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR reorganizes the tests into unit tests for individual methods and integration tests for the entire parsing of an article. It also adds an extra check for cases where `parseDate` finds a year and a day of month without a month, which indicates that the month was either missing in the dataset or could not be parsed correctly. We would previously fall back to returning only a year in that case.

This PR should be merged after PR #26.