### PR TITLE
Install WartRemover and Scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,7 @@
 # Copied from https://github.com/spotify/scio/blob/90fe007b8f5f7c21e42e6d66675ef1cd069fa718/.scalafmt.conf
 version = "2.2.2"
 maxColumn = 100
+align = more
 
 binPack.literalArgumentLists = true
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = 2.0.0-RC8
+maxColumn = 100

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,25 @@
-version = 2.0.0-RC8
+# Copied from https://github.com/spotify/scio/blob/90fe007b8f5f7c21e42e6d66675ef1cd069fa718/.scalafmt.conf
+version = "2.2.2"
 maxColumn = 100
+
+binPack.literalArgumentLists = true
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+newlines {
+  afterImplicitKWInVerticalMultiline = true
+  beforeImplicitKWInVerticalMultiline = true
+  sometimesBeforeColonInMethodReturnType = true
+}
+
+docstrings = JavaDoc
+
+project.git = false
+
+rewrite {
+  rules = [PreferCurlyFors, RedundantBraces, RedundantParens, SortImports]
+  redundantBraces.maxLines = 1
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,26 +1,4 @@
-# Copied from https://github.com/spotify/scio/blob/90fe007b8f5f7c21e42e6d66675ef1cd069fa718/.scalafmt.conf
 version = "2.2.2"
+style = IntelliJ
 maxColumn = 100
 align = more
-
-binPack.literalArgumentLists = true
-
-continuationIndent {
-  callSite = 2
-  defnSite = 2
-}
-
-newlines {
-  afterImplicitKWInVerticalMultiline = true
-  beforeImplicitKWInVerticalMultiline = true
-  sometimesBeforeColonInMethodReturnType = true
-}
-
-docstrings = JavaDoc
-
-project.git = false
-
-rewrite {
-  rules = [PreferCurlyFors, RedundantBraces, RedundantParens, SortImports]
-  redundantBraces.maxLines = 1
-}

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ mainClass in Compile := Some("org.renci.chemotext.Main")
 
 // Code formatting and linting tools.
 
-wartremoverErrors ++= Warts.unsafe
+wartremoverWarnings ++= Warts.unsafe
 
 // Running and command line options.
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 
 scalaVersion  := "2.12.8" //Neo4j has a 2.11 Scala dependency but it seems to be only for the cypher parser
 
-scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
 scalacOptions in Test ++= Seq("-Yrangepos")
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ version       := "0.1-SNAPSHOT"
 
 licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT"))
 
+// Scalac options.
+
 scalaVersion  := "2.12.8" //Neo4j has a 2.11 Scala dependency but it seems to be only for the cypher parser
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
@@ -16,11 +18,19 @@ scalacOptions in Test ++= Seq("-Yrangepos")
 
 mainClass in Compile := Some("org.renci.chemotext.Main")
 
+// Code formatting and linting tools.
+
+wartremoverErrors ++= Warts.unsafe
+
+// Running and command line options.
+
 javaOptions += "-Xmx20G"
 
 fork in Test := true
 
 testFrameworks += new TestFramework("utest.runner.Framework")
+
+// Dependency information.
 
 resolvers += Resolver.mavenLocal
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.3")
+
+// Code formatting and linting tools.
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")

--- a/src/main/scala/org/renci/chemotext/Annotator.scala
+++ b/src/main/scala/org/renci/chemotext/Annotator.scala
@@ -11,15 +11,15 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.prefixcommons.CurieUtil
 
 class Annotator(neo4jLocation: String) {
-
-  private val curieUtil: CurieUtil = new CurieUtil(new HashMap())
+  private val curieUtil: CurieUtil         = new CurieUtil(new HashMap())
   private val transformer: NodeTransformer = new NodeTransformer()
-  private val graph: GraphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase(new File(neo4jLocation))
-  private val vocabulary: Vocabulary = new VocabularyNeo4jImpl(graph, neo4jLocation, curieUtil, transformer)
+  private val graph: GraphDatabaseService =
+    new GraphDatabaseFactory().newEmbeddedDatabase(new File(neo4jLocation))
+  private val vocabulary: Vocabulary =
+    new VocabularyNeo4jImpl(graph, neo4jLocation, curieUtil, transformer)
   private val recognizer = new EntityRecognizer(vocabulary, curieUtil)
 
   val processor = new EntityProcessorImpl(recognizer)
 
   def dispose(): Unit = graph.shutdown()
-
 }

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -41,7 +41,7 @@ object PubMedArticleWrapper {
       val medlineDate            = (date \\ "MedlineDate").text
       medlineDate match {
         case medlineDateYearMatcher(year) => Success(Year.of(year.toInt))
-        case _                            => Failure(new IllegalArgumentException("Could not parse XML node as date: " + date))
+        case _                            => Failure(new IllegalArgumentException(s"Could not parse XML node as date: $date"))
       }
     }
 
@@ -67,7 +67,7 @@ object PubMedArticleWrapper {
         // What if we have a maybeYear and a maybeDayOfMonth, but no maybeMonth?
         // That suggests that we didn't read the month correctly!
         if (maybeYear.isSuccess && maybeDayOfMonth.isSuccess && maybeMonth.isFailure)
-          Failure(new RuntimeException("Could not extract month from node: " + date))
+          Failure(new RuntimeException(s"Could not extract month from node: $date"))
         else Success(Year.of(year))
       })
     } getOrElse (parseMedlineDate(date))
@@ -182,7 +182,7 @@ object Main extends App with LazyLogging {
           case Success(year: Year) =>
             ResourceFactory.createTypedLiteral(year.toString, XSDDatatype.XSDgYear)
           case Success(ta: TemporalAccessor) =>
-            throw new RuntimeException("Unexpected temporal accessor found by parsing date: " + ta)
+            throw new RuntimeException(s"Unexpected temporal accessor found by parsing date: $ta")
           case Failure(error: Throwable) => throw error
         }
       )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -7,10 +7,11 @@ import utest._
 import scala.xml.XML
 
 /**
- * Integration tests of PubmedArticleWrapper.
- */
+  * Integration tests of PubmedArticleWrapper.
+  */
 object PubMedArticleWrapperIntegrationTests extends TestSuite {
-  val examplesForTests = XML.loadFile(getClass.getResource("/pubmedXML/examplesForTests.xml").getPath)
+  val examplesForTests =
+    XML.loadFile(getClass.getResource("/pubmedXML/examplesForTests.xml").getPath)
   val pubmedArticles = examplesForTests \ "PubmedArticle"
 
   val tests = Tests {
@@ -18,8 +19,41 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(0))
 
       assert(wrappedArticle.pmid == "11237011")
-      assert(wrappedArticle.asString == "Initial sequencing and analysis of the human genome. The human genome holds an extraordinary trove of information about human development, physiology, medicine and evolution. Here we report the results of an international collaboration to produce and make freely available a draft sequence of the human genome. We also present an initial analysis of the data, describing some of the insights that can be gleaned from the sequence. Genetics, Medical CpG Islands Public Sector Gene Duplication Proteins Databases, Factual Proteome Proteins genetics Repetitive Sequences, Nucleic Acid Forecasting GC Rich Sequence Drug Industry Genes Sequence Analysis, DNA methods Humans Animals DNA Transposable Elements Private Sector Mutation Conserved Sequence Genome, Human RNA RNA genetics Evolution, Molecular Human Genome Project Chromosome Mapping Species Specificity Genetic Diseases, Inborn ")
-      assert(wrappedArticle.allMeshTermIDs == Set("D002874", "D019143", "D017124", "D005826", "D013045", "D005796", "D018899", "D016208", "D012313", "D000818", "D015894", "D017149", "D006801", "D004345", "D020862", "D020543", "D017422", "D004251", "D017150", "D009154", "D005544", "D016045", "Q000235", "D011506", "Q000379", "D020440", "D012091", "D030342"))
+      assert(
+        wrappedArticle.asString == "Initial sequencing and analysis of the human genome. The human genome holds an extraordinary trove of information about human development, physiology, medicine and evolution. Here we report the results of an international collaboration to produce and make freely available a draft sequence of the human genome. We also present an initial analysis of the data, describing some of the insights that can be gleaned from the sequence. Genetics, Medical CpG Islands Public Sector Gene Duplication Proteins Databases, Factual Proteome Proteins genetics Repetitive Sequences, Nucleic Acid Forecasting GC Rich Sequence Drug Industry Genes Sequence Analysis, DNA methods Humans Animals DNA Transposable Elements Private Sector Mutation Conserved Sequence Genome, Human RNA RNA genetics Evolution, Molecular Human Genome Project Chromosome Mapping Species Specificity Genetic Diseases, Inborn "
+      )
+      assert(
+        wrappedArticle.allMeshTermIDs == Set(
+          "D002874",
+          "D019143",
+          "D017124",
+          "D005826",
+          "D013045",
+          "D005796",
+          "D018899",
+          "D016208",
+          "D012313",
+          "D000818",
+          "D015894",
+          "D017149",
+          "D006801",
+          "D004345",
+          "D020862",
+          "D020543",
+          "D017422",
+          "D004251",
+          "D017150",
+          "D009154",
+          "D005544",
+          "D016045",
+          "Q000235",
+          "D011506",
+          "Q000379",
+          "D020440",
+          "D012091",
+          "D030342"
+        )
+      )
       assert(wrappedArticle.pubDates == Seq(LocalDate.of(2001, 2, 15)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2019, 2, 8)))
     }
@@ -28,8 +62,28 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(1))
 
       assert(wrappedArticle.pmid == "17060194")
-      assert(wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity ")
-      assert(wrappedArticle.allMeshTermIDs == Set("D004175", "D001483", "D013045", "D016384", "D000818", "D010802", "D004272", "D002965", "D017422", "D003576", "Q000737", "Q000145", "Q000235", "D014644", "Q000379"))
+      assert(
+        wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity "
+      )
+      assert(
+        wrappedArticle.allMeshTermIDs == Set(
+          "D004175",
+          "D001483",
+          "D013045",
+          "D016384",
+          "D000818",
+          "D010802",
+          "D004272",
+          "D002965",
+          "D017422",
+          "D003576",
+          "Q000737",
+          "Q000145",
+          "Q000235",
+          "D014644",
+          "Q000379"
+        )
+      )
       assert(wrappedArticle.pubDates == Seq(YearMonth.of(2006, 10)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2008, 11, 21)))
     }
@@ -38,7 +92,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(2))
 
       assert(wrappedArticle.pmid == "22859891")
-      assert(wrappedArticle.asString == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks. Part diary, part scientific record, biological field notebooks often contain details necessary to understanding the location and environmental conditions existent during collecting events. Despite their clear value for (and recent use in) global change studies, the text-mining outputs from field notebooks have been idiosyncratic to specific research projects, and impossible to discover or re-use. Best practices and workflows for digitization, transcription, extraction, and integration with other sources are nascent or non-existent. In this paper, we demonstrate a workflow to generate structured outputs while also maintaining links to the original texts. The first step in this workflow was to place already digitized and transcribed field notebooks from the University of Colorado Museum of Natural History founder, Junius Henderson, on Wikisource, an open text transcription platform. Next, we created Wikisource templates to document places, dates, and taxa to facilitate annotation and wiki-linking. We then requested help from the public, through social media tools, to take advantage of volunteer efforts and energy. After three notebooks were fully annotated, content was converted into XML and annotations were extracted and cross-walked into Darwin Core compliant record sets. Finally, these recordsets were vetted, to provide valid taxon names, via a process we call \"taxonomic referencing.\" The result is identification and mobilization of 1,068 observations from three of Henderson's thirteen notebooks and a publishable Darwin Core record set for use in other analyses. Although challenges remain, this work demonstrates a feasible approach to unlock observations from field notebooks that enhances their discovery and interoperability without losing the narrative context from which those observations are drawn.\"Compose your notes as if you were writing a letter to someone a century in the future.\"Perrine and Patton (2011).  ")
+      assert(
+        wrappedArticle.asString == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks. Part diary, part scientific record, biological field notebooks often contain details necessary to understanding the location and environmental conditions existent during collecting events. Despite their clear value for (and recent use in) global change studies, the text-mining outputs from field notebooks have been idiosyncratic to specific research projects, and impossible to discover or re-use. Best practices and workflows for digitization, transcription, extraction, and integration with other sources are nascent or non-existent. In this paper, we demonstrate a workflow to generate structured outputs while also maintaining links to the original texts. The first step in this workflow was to place already digitized and transcribed field notebooks from the University of Colorado Museum of Natural History founder, Junius Henderson, on Wikisource, an open text transcription platform. Next, we created Wikisource templates to document places, dates, and taxa to facilitate annotation and wiki-linking. We then requested help from the public, through social media tools, to take advantage of volunteer efforts and energy. After three notebooks were fully annotated, content was converted into XML and annotations were extracted and cross-walked into Darwin Core compliant record sets. Finally, these recordsets were vetted, to provide valid taxon names, via a process we call \"taxonomic referencing.\" The result is identification and mobilization of 1,068 observations from three of Henderson's thirteen notebooks and a publishable Darwin Core record set for use in other analyses. Although challenges remain, this work demonstrates a feasible approach to unlock observations from field notebooks that enhances their discovery and interoperability without losing the narrative context from which those observations are drawn.\"Compose your notes as if you were writing a letter to someone a century in the future.\"Perrine and Patton (2011).  "
+      )
       assert(wrappedArticle.allMeshTermIDs == Set())
       assert(wrappedArticle.pubDates == Seq(Year.of(2012)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2018, 11, 13)))
@@ -48,8 +104,20 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(3))
 
       assert(wrappedArticle.pmid == "10542500")
-      assert(wrappedArticle.asString == "Thirty years of service.  Parkinson Disease therapy United Kingdom Humans Organizational Objectives Information Services Societies ")
-      assert(wrappedArticle.allMeshTermIDs == Set("D012952", "D007255", "D006801", "D010300", "D006113", "Q000628", "D009937"))
+      assert(
+        wrappedArticle.asString == "Thirty years of service.  Parkinson Disease therapy United Kingdom Humans Organizational Objectives Information Services Societies "
+      )
+      assert(
+        wrappedArticle.allMeshTermIDs == Set(
+          "D012952",
+          "D007255",
+          "D006801",
+          "D010300",
+          "D006113",
+          "Q000628",
+          "D009937"
+        )
+      )
       assert(wrappedArticle.pubDates == Seq(Year.of(1998)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2016, 11, 24)))
     }

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -8,38 +8,42 @@ import scala.util.{Success, Failure}
 import scala.xml.XML
 
 /**
- * Unit tests for the PubMedArticleWrapper class.
- */
+  * Unit tests for the PubMedArticleWrapper class.
+  */
 object PubMedArticleWrapperUnitTests extends TestSuite {
   val tests = Tests {
     test("#parseDate") {
       test("Test processing of valid dates") {
         val datesTested = Seq(
-          (Year.of(2006),               <PubDate><Year>2006</Year></PubDate>),
-          (YearMonth.of(2006, 10),      <PubDate><Year>2006</Year><Month>Oct</Month></PubDate>),
-          (LocalDate.of(2006, 10, 21),  <PubDate><Year>2006</Year><Day>21</Day><Month>Oct</Month></PubDate>),
-          (Year.of(1998),               <PubDate><MedlineDate>1998 Dec-1999 Jan</MedlineDate></PubDate>),
+          (Year.of(2006), <PubDate><Year>2006</Year></PubDate>),
+          (YearMonth.of(2006, 10), <PubDate><Year>2006</Year><Month>Oct</Month></PubDate>),
+          (
+            LocalDate.of(2006, 10, 21),
+            <PubDate><Year>2006</Year><Day>21</Day><Month>Oct</Month></PubDate>
+          ),
+          (Year.of(1998), <PubDate><MedlineDate>1998 Dec-1999 Jan</MedlineDate></PubDate>),
           (
             LocalDate.of(2006, 10, 21),
             <PubDate><Year>2006</Year><Day>21</Day><Month>10</Month></PubDate>
           )
         )
 
-        datesTested.foreach({ case (expected, xmlNode) =>
-          assert(PubMedArticleWrapper.parseDate(xmlNode) == Success(expected))
+        datesTested.foreach({
+          case (expected, xmlNode) =>
+            assert(PubMedArticleWrapper.parseDate(xmlNode) == Success(expected))
         })
       }
       test("Test processing of invalid dates") {
         assert(
           (intercept[IllegalArgumentException] {
-            PubMedArticleWrapper.parseDate(<PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>).get
+            PubMedArticleWrapper
+              .parseDate(<PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>)
+              .get
           }).getMessage == "Could not parse XML node as date: <PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>"
         )
-        assert(
-          (intercept[IllegalArgumentException] {
-            PubMedArticleWrapper.parseDate(<PubDate></PubDate>).get
-          }).getMessage == "Could not parse XML node as date: <PubDate></PubDate>"
-        )
+        assert((intercept[IllegalArgumentException] {
+          PubMedArticleWrapper.parseDate(<PubDate></PubDate>).get
+        }).getMessage == "Could not parse XML node as date: <PubDate></PubDate>")
         assert(
           (intercept[RuntimeException] {
             PubMedArticleWrapper.parseDate(<PubDate><Year>2019</Year><Day>12</Day></PubDate>).get


### PR DESCRIPTION
This PR installs WartRemover and Scalafmt. WartRemover warnings will be displayed when code is being compiled. Scalafmt can be used to reformat the Scala code in this repository by running `sbt scalafmtAll`. I've also reformatted all the source code using Scalafmt.