### PR TITLE
Add journal metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= {
     "com.typesafe.scala-logging"  %% "scala-logging"          % "3.7.1",
     "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
-    "org.apache.jena"             %  "apache-jena-libs"       % "3.2.0", //pomOnly()
+    "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
   )
 }

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -49,7 +49,7 @@ class AuthorWrapper(node: Node) {
   // TODO: add support for <EqualContrib>
 
   // Support for identifiers.
-  val identifier          = (node \ "Identifier").map(id => (id.attribute("Source") -> id.text))
+  val identifier          = (node \ "Identifier").map(id => (id.attribute("Source").map(_.text).mkString(", ") -> id.text))
   val orcIds: Seq[String] = identifier.filter(_._1 == "ORCID").map(_._2)
 
   // FOAF uses foaf:givenName and foaf:familyName.

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -104,6 +104,10 @@ class PubMedArticleWrapper(val article: Node) {
   val articleDates: Seq[TemporalAccessor] = articleDatesParseResults.map(_.toOption).flatten
   val revisedDates: Seq[TemporalAccessor] = revisedDatesParseResults.map(_.toOption).flatten
 
+  // Extract journal metadata.
+  val articleInfo: Map[String, Seq[String]] = ???
+  val doi: Seq[String] = articleInfo("doi")
+
   // Extract gene symbols and MeSH headings.
   val geneSymbols: String = (article \\ "GeneSymbol").map(_.text).mkString(" ")
   val (meshTermIDs, meshLabels) = (article \\ "MeshHeading").map { mh =>

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -335,7 +335,9 @@ object PubMedTripleGenerator {
       //    }
       //  }
       val journalModel = ModelFactory.createDefaultModel
-      val journalResource = journalModel.createResource(s"$FaBiONamespace/JournalIssue")
+      val journalResource = journalModel.createResource(
+        ResourceFactory.createResource(s"$FaBiONamespace/JournalIssue")
+      )
         .addProperty(DCTerms.title, pubMedArticleWrapped.journalTitle)
         .addProperty(
           ResourceFactory.createProperty(s"$FaBiONamespace/hasNLMJournalTitleAbbreviation"),
@@ -343,7 +345,9 @@ object PubMedTripleGenerator {
         )
         // TODO: Add ISSN and eISSN
 
-      val volumeResource = journalModel.createResource(s"$FaBiONamespace/JournalVolume")
+      val volumeResource = journalModel.createResource(
+        ResourceFactory.createResource(s"$FaBiONamespace/JournalVolume")
+      )
         .addProperty(
           ResourceFactory.createProperty(s"$PRISMBasicNamespace/volume"),
           pubMedArticleWrapped.journalVolume
@@ -353,7 +357,9 @@ object PubMedTripleGenerator {
           journalResource
         )
 
-      val issueResource = journalModel.createResource(s"$FaBiONamespace/JournalIssue")
+      val issueResource = journalModel.createResource(
+        ResourceFactory.createResource(s"$FaBiONamespace/JournalIssue")
+      )
         .addProperty(
           ResourceFactory.createProperty(s"$PRISMBasicNamespace/issueIdentifier"),
           pubMedArticleWrapped.journalIssue

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -411,13 +411,28 @@ object PubMedTripleGenerator {
     val authorStatements = authorModel.listStatements.toList.asScala :+ ResourceFactory
       .createStatement(pmidIRI, DCTerms.creator, authorRDFList)
 
+    // Build a string citation from the provided information.
+    val authorString = pubMedArticleWrapped.authors.map(_.name).mkString(", ")
+    val titleString = pubMedArticleWrapped.title
+    val journalTitle = pubMedArticleWrapped.journalTitle
+    val pubYear = pubMedArticleWrapped.pubDateYears.mkString(", ")
+    val journalVolume = pubMedArticleWrapped.journalVolume
+    val journalIssue = pubMedArticleWrapped.journalIssue
+    val journalPages = pubMedArticleWrapped.medlinePagination
+    val pmid = pubMedArticleWrapped.pmid
+    val citationString = s"$authorString. $titleString. $journalTitle ($pubYear);$journalVolume($journalIssue):$journalPages. PubMed PMID: $pmid"
+
     val metadataStatements = publicationMetadataStatements ++
       authorStatements ++
       (pubMedArticleWrapped.pubDatesParseResults map convertDatesToTriples(pmidIRI, DCTerms.issued)) ++
       (pubMedArticleWrapped.revisedDatesParseResults map convertDatesToTriples(
         pmidIRI,
         DCTerms.modified
-      ))
+      )) :+ ResourceFactory.createStatement(
+        pmidIRI,
+        DCTerms.bibliographicCitation,
+        ResourceFactory.createStringLiteral(citationString)
+      )
 
     // Extract meshIRIs as RDF statements.
     val meshIRIs = pubMedArticleWrapped.allMeshTermIDs map (

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -216,6 +216,7 @@ object PubMedTripleGenerator {
   val MESHNamespace = "http://id.nlm.nih.gov/mesh"
   val PRISMBasicNamespace = "http://prismstandard.org/namespaces/basic/3.0"
   val FOAFNamespace = "http://xmlns.com/foaf/0.1"
+  val FaBiONamespace = "http://purl.org/spar/fabio"
 
   // Extract dates as RDF statements.
   def convertDatesToTriples(pmidIRI: Resource, property: Property)(
@@ -260,7 +261,14 @@ object PubMedTripleGenerator {
             prop,
             ResourceFactory.createTypedLiteral(value.mkString(", "), XSDDatatype.XSDstring)
           )
-      })
+      }) ++ Seq(
+        // <pmidIRI> a fabio:Article
+        ResourceFactory.createStatement(
+          pmidIRI,
+          RDF.`type`,
+          ResourceFactory.createResource(s"$FaBiONamespace/Article")
+        )
+      )
 
     val authorStatements = pubMedArticleWrapped.authors.flatMap({ author =>
       val authorRes = ResourceFactory.createResource()

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -58,6 +58,7 @@ class AuthorWrapper(node: Node) {
     if (suffix.isEmpty) lastName else s"$lastName $suffix"
   }
   val name: String = if (!collectiveName.isEmpty) collectiveName else s"$givenName $familyName"
+  val shortName: String = if (initials.isEmpty) lastName else s"$lastName $initials"
 }
 
 object AuthorWrapper {
@@ -412,7 +413,7 @@ object PubMedTripleGenerator {
       .createStatement(pmidIRI, DCTerms.creator, authorRDFList)
 
     // Build a string citation from the provided information.
-    val authorString = pubMedArticleWrapped.authors.map(_.name).mkString(", ")
+    val authorString = pubMedArticleWrapped.authors.map(_.shortName).mkString(", ")
     val titleString = pubMedArticleWrapped.title + (if (pubMedArticleWrapped.title.endsWith(".")) "" else ".")
     val journalTitle = pubMedArticleWrapped.journalTitle
     val pubYear = pubMedArticleWrapped.pubDateYears.mkString(", ")

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -177,6 +177,10 @@ class Annotator(neo4jLocation: String) {
 
 /** Methods for generating an RDF description of a PubMedArticleWrapper. */
 object PubMedTripleGenerator {
+  // Some namespaces.
+  val MESHNamespace = "http://id.nlm.nih.gov/mesh"
+  val PRISMBasicNamespace = "http://prismstandard.org/namespaces/basic/3.0"
+
   // Extract dates as RDF statements.
   def convertDatesToTriples(pmidIRI: Resource, property: Property)(
     date: Try[TemporalAccessor]
@@ -208,8 +212,8 @@ object PubMedTripleGenerator {
 
     // Add publication metadata.
     val publicationMetadata = Seq(
-      ResourceFactory
-        .createProperty("http://prismstandard.org/namespaces/basic/3.0/doi") -> pubMedArticleWrapped.doi
+      DCTerms.title -> Seq(pubMedArticleWrapped.title),
+      ResourceFactory.createProperty(s"$PRISMBasicNamespace/doi") -> pubMedArticleWrapped.doi
     )
     val publicationMetadataStatements = publicationMetadata
       .filter(!_._2.isEmpty)
@@ -230,7 +234,6 @@ object PubMedTripleGenerator {
       ))
 
     // Extract meshIRIs as RDF statements.
-    val MESHNamespace = "http://id.nlm.nih.gov/mesh"
     val meshIRIs = pubMedArticleWrapped.allMeshTermIDs map (
       id => ResourceFactory.createResource(s"$MESHNamespace/$id")
     )

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -23,7 +23,7 @@ import org.apache.jena.datatypes.xsd.XSDDatatype
 import org.apache.jena.graph
 import org.apache.jena.rdf.model.{ModelFactory, Property, Resource, ResourceFactory, Statement}
 import org.apache.jena.riot.Lang
-import org.apache.jena.riot.system.{StreamOps, StreamRDFWriter}
+import org.apache.jena.riot.system.{StreamRDFOps, StreamRDFWriter}
 import org.apache.jena.vocabulary.{DCTerms, RDF}
 import org.apache.jena.sparql.vocabulary.FOAF
 import org.apache.lucene.queryparser.classic.QueryParserBase
@@ -469,7 +469,7 @@ object Main extends App with LazyLogging {
         }
       }
       .runForeach { triples =>
-        StreamOps.sendTriplesToStream(triples.iterator.asJava, rdfStream)
+        StreamRDFOps.sendTriplesToStream(triples.iterator.asJava, rdfStream)
       }
 
     Await.ready(done, Duration.Inf).onComplete {

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -151,16 +151,12 @@ class PubMedArticleWrapper(val article: Node) {
     )
     .mapValues(_.map(_.text))
   val dois: Seq[String] = articleIdInfo.getOrElse("doi", Seq())
-  val authors: Seq[AuthorWrapper] = {
-    val authorListNodes = (article \\ "AuthorList")
-    if (authorListNodes.isEmpty) Seq() else {
-      val authorListNode  = authorListNodes.head
+  val authors: Seq[AuthorWrapper] = (article \\ "AuthorList").headOption.map(authorListNode => {
       val authorList      = authorListNode.nonEmptyChildren.map(new AuthorWrapper(_))
       if (authorListNode.attribute("CompleteYN") == "N")
         (authorList :+ AuthorWrapper.ET_AL)
       else authorList
-    }
-  }
+  }).getOrElse(Seq())
 
   // Extract gene symbols and MeSH headings.
   val geneSymbols: String = (article \\ "GeneSymbol").map(_.text).mkString(" ")

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -392,8 +392,11 @@ object PubMedTripleGenerator {
 
     val authorModel = ModelFactory.createDefaultModel
     val authorResources = pubMedArticleWrapped.authors.map({ author =>
-      authorModel
-        .createResource(FOAF.Agent)
+      (
+        // If we have an ORCID for this author, use that to create a URL for this author. Otherwise, leave it as a blank node.
+        if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent)
+        else authorModel.createResource(s"http://orcid.org/${author.orcIds.headOption.getOrElse("")}#person", FOAF.Agent)
+      )
         .addProperty(
           ResourceFactory.createProperty(s"$FOAFNamespace/familyName"),
           ResourceFactory.createTypedLiteral(author.familyName, XSDDatatype.XSDstring)

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -336,7 +336,7 @@ object PubMedTripleGenerator {
       //  }
       val journalModel = ModelFactory.createDefaultModel
       val journalResource = journalModel.createResource(
-        ResourceFactory.createResource(s"$FaBiONamespace/JournalIssue")
+        ResourceFactory.createResource(s"$FaBiONamespace/Journal")
       )
         .addProperty(DCTerms.title, pubMedArticleWrapped.journalTitle)
         .addProperty(

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -343,7 +343,19 @@ object PubMedTripleGenerator {
           ResourceFactory.createProperty(s"$FaBiONamespace/hasNLMJournalTitleAbbreviation"),
           pubMedArticleWrapped.journalAbbr
         )
-        // TODO: Add ISSN and eISSN
+
+      pubMedArticleWrapped.journalISSNNodes.foreach(issnNode => {
+        val prismPropName = issnNode.attribute("IssnType").map(_.text) match {
+          case Some("Electronic") => "eIssn"
+          case Some("Print")      => "issn"
+          case _                       => "issn"
+        }
+
+        journalResource.addProperty(
+          ResourceFactory.createProperty(s"$PRISMBasicNamespace/$prismPropName"),
+          issnNode.text
+        )
+      })
 
       val volumeResource = journalModel.createResource(
         ResourceFactory.createResource(s"$FaBiONamespace/JournalVolume")

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -112,7 +112,7 @@ class PubMedArticleWrapper(val article: Node) {
         .mkString(" & ")           // if there are multiple, combine them with ' & '.
     )
     .mapValues(_.map(_.text))
-  val doi: Seq[String] = articleIdInfo.getOrElse("doi", Seq())
+  val dois: Seq[String] = articleIdInfo.getOrElse("doi", Seq())
 
   // Extract gene symbols and MeSH headings.
   val geneSymbols: String = (article \\ "GeneSymbol").map(_.text).mkString(" ")
@@ -213,7 +213,7 @@ object PubMedTripleGenerator {
     // Add publication metadata.
     val publicationMetadata = Seq(
       DCTerms.title -> Seq(pubMedArticleWrapped.title),
-      ResourceFactory.createProperty(s"$PRISMBasicNamespace/doi") -> pubMedArticleWrapped.doi
+      ResourceFactory.createProperty(s"$PRISMBasicNamespace/doi") -> pubMedArticleWrapped.dois
     )
     val publicationMetadataStatements = publicationMetadata
       .filter(!_._2.isEmpty)

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -151,11 +151,14 @@ class PubMedArticleWrapper(val article: Node) {
     .mapValues(_.map(_.text))
   val dois: Seq[String] = articleIdInfo.getOrElse("doi", Seq())
   val authors: Seq[AuthorWrapper] = {
-    val authorListNode = (article \\ "AuthorList").head
-    val authorList     = authorListNode.nonEmptyChildren.map(new AuthorWrapper(_))
-    if (authorListNode.attribute("CompleteYN") == "N")
-      (authorList :+ AuthorWrapper.ET_AL)
-    else authorList
+    val authorListNodes = (article \\ "AuthorList")
+    if (authorListNodes.isEmpty) Seq() else {
+      val authorListNode  = authorListNodes.head
+      val authorList      = authorListNode.nonEmptyChildren.map(new AuthorWrapper(_))
+      if (authorListNode.attribute("CompleteYN") == "N")
+        (authorList :+ AuthorWrapper.ET_AL)
+      else authorList
+    }
   }
 
   // Extract gene symbols and MeSH headings.

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -147,7 +147,7 @@ class PubMedArticleWrapper(val article: Node) {
   val authors: Seq[AuthorWrapper] = {
     val authorListNode = (article \\ "AuthorList").head
     val authorList     = authorListNode.nonEmptyChildren.map(new AuthorWrapper(_))
-    if (authorListNode.attribute("CompleteYN") == "Y")
+    if (authorListNode.attribute("CompleteYN") == "N")
       (authorList :+ AuthorWrapper.ET_AL)
     else authorList
   }

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -155,7 +155,7 @@ class PubMedArticleWrapper(val article: Node) {
   val authors: Seq[AuthorWrapper] = (article \\ "AuthorList").headOption
     .map(authorListNode => {
       val authorList = authorListNode.nonEmptyChildren.map(new AuthorWrapper(_))
-      if (authorListNode.attribute("CompleteYN") == "N")
+      if (authorListNode.attribute("CompleteYN").map(_.text).mkString(", ") == "N")
         (authorList :+ AuthorWrapper.ET_AL)
       else authorList
     })

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -413,14 +413,14 @@ object PubMedTripleGenerator {
 
     // Build a string citation from the provided information.
     val authorString = pubMedArticleWrapped.authors.map(_.name).mkString(", ")
-    val titleString = pubMedArticleWrapped.title
+    val titleString = pubMedArticleWrapped.title + (if (pubMedArticleWrapped.title.endsWith(".")) "" else ".")
     val journalTitle = pubMedArticleWrapped.journalTitle
     val pubYear = pubMedArticleWrapped.pubDateYears.mkString(", ")
     val journalVolume = pubMedArticleWrapped.journalVolume
-    val journalIssue = pubMedArticleWrapped.journalIssue
+    val journalIssue = if (pubMedArticleWrapped.journalIssue.isEmpty) "" else s"(${pubMedArticleWrapped.journalIssue})"
     val journalPages = pubMedArticleWrapped.medlinePagination
     val pmid = pubMedArticleWrapped.pmid
-    val citationString = s"$authorString. $titleString. $journalTitle ($pubYear);$journalVolume($journalIssue):$journalPages. PubMed PMID: $pmid"
+    val citationString = s"$authorString. $titleString $journalTitle ($pubYear);$journalVolume$journalIssue:$journalPages. PubMed PMID: $pmid"
 
     val metadataStatements = publicationMetadataStatements ++
       authorStatements ++

--- a/src/test/resources/pubmedXML/examplesForTests.xml
+++ b/src/test/resources/pubmedXML/examplesForTests.xml
@@ -1556,6 +1556,7 @@
                       <LastName>Vaidya</LastName>
                       <ForeName>Gaurav</ForeName>
                       <Initials>G</Initials>
+                      <Identifier Source="ORCID">0000000305870454</Identifier>
                   </Author>
                   <Author ValidYN="Y">
                       <LastName>Ng</LastName>

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -243,8 +243,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
                                     prism:issueIdentifier  "5" ;
                                     frbr:partOf            [ a             fabio:JournalVolume ;
                                                              prism:volume  "55" ;
-                                                             frbr:partOf   [ a          fabio:JournalIssue ;
                                                                              dct:title  "Systematic biology" ;
+                                                             frbr:partOf   [ a           fabio:Journal ;
                                                                              fabio:hasNLMJournalTitleAbbreviation
                                                                                      "Syst. Biol."
                                                                            ]

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -268,8 +268,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val foundGraph = graph.Factory.createDefaultGraph
       triples.foreach(foundGraph.add(_))
       val stringWriter = new StringWriter()
-      val model        = ModelFactory.createModelForGraph(foundGraph)
-      model.setNsPrefixes(
+      val model        = ModelFactory.createModelForGraph(foundGraph).setNsPrefixes(
         Map(
           "dct"   -> "http://purl.org/dc/terms/",
           "fabio" -> "http://purl.org/spar/fabio/",

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -11,6 +11,7 @@ import utest._
 import collection.mutable
 import collection.JavaConverters._
 import scala.xml.XML
+import scala.math.max
 
 /**
   * Integration tests of PubmedArticleWrapper.

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -121,10 +121,10 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),
-            "http://purl.org/vocab/frbr/core#partOf" -> Map(
-              "blank" -> 1
-            ),
-            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/vocab/frbr/core#partOf" -> Map("blank" -> 1),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )
@@ -174,8 +174,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "http://orcid.org/0000000305870454#person" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
-            "http://xmlns.com/foaf/0.1/familyName" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
-            "http://xmlns.com/foaf/0.1/givenName" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://xmlns.com/foaf/0.1/familyName" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://xmlns.com/foaf/0.1/givenName" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           ),
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
@@ -203,10 +207,10 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),
-            "http://purl.org/vocab/frbr/core#partOf" -> Map(
-              "blank" -> 1
-            ),
-            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/vocab/frbr/core#partOf" -> Map("blank" -> 1),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )
@@ -268,20 +272,22 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val foundGraph = graph.Factory.createDefaultGraph
       triples.foreach(foundGraph.add(_))
       val stringWriter = new StringWriter()
-      val model        = ModelFactory.createModelForGraph(foundGraph).setNsPrefixes(
-        Map(
-          "dct"   -> "http://purl.org/dc/terms/",
-          "fabio" -> "http://purl.org/spar/fabio/",
-          "frbr"  -> "http://purl.org/vocab/frbr/core#",
-          "foaf"  -> "http://xmlns.com/foaf/0.1/",
-          "xsd"   -> "http://www.w3.org/2001/XMLSchema#",
-          "prism" -> "http://prismstandard.org/namespaces/basic/3.0/"
-        ).asJava
-      )
+      val model = ModelFactory
+        .createModelForGraph(foundGraph)
+        .setNsPrefixes(
+          Map(
+            "dct"   -> "http://purl.org/dc/terms/",
+            "fabio" -> "http://purl.org/spar/fabio/",
+            "frbr"  -> "http://purl.org/vocab/frbr/core#",
+            "foaf"  -> "http://xmlns.com/foaf/0.1/",
+            "xsd"   -> "http://www.w3.org/2001/XMLSchema#",
+            "prism" -> "http://prismstandard.org/namespaces/basic/3.0/"
+          ).asJava
+        )
       val baos = new ByteArrayOutputStream()
       RDFWriter.create.source(model).format(RDFFormat.TURTLE_PRETTY).output(baos);
 
-      val actual = baos.toString("UTF-8").split("\n")
+      val actual   = baos.toString("UTF-8").split("\n")
       val expected = expectedTriplesAsTurtle.split("\n")
 
       // assert(baos.toString("UTF-8") == expectedTriplesAsTurtle)
@@ -335,10 +341,10 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),
-            "http://purl.org/vocab/frbr/core#partOf" -> Map(
-              "blank" -> 1
-            ),
-            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/vocab/frbr/core#partOf" -> Map("blank" -> 1),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )
@@ -380,7 +386,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://purl.org/dc/terms/creator"    -> Map("blank"                                   -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#gYear"  -> 1),
-            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1),
+            "http://purl.org/dc/terms/modified" -> Map(
+              "http://www.w3.org/2001/XMLSchema#date" -> 1
+            ),
             "http://prismstandard.org/namespaces/basic/3.0/pageRange" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),
@@ -390,10 +398,10 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),
-            "http://purl.org/vocab/frbr/core#partOf" -> Map(
-              "blank" -> 1
-            ),
-            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/vocab/frbr/core#partOf" -> Map("blank" -> 1),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -219,7 +219,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         prism:endingPage           "28" ;
         prism:pageRange            "715-28" ;
         prism:startingPage         "715" ;
-        dct:bibliographicCitation  "Rudolf Meier, Kwong Shiyang, Gaurav Vaidya, Peter K L Ng. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
+        dct:bibliographicCitation  "Meier R, Shiyang K, Vaidya G, Ng PK. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
         dct:creator                ( [ a                foaf:Agent ;
                                        foaf:familyName  "Meier" ;
                                        foaf:givenName   "Rudolf"

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -84,7 +84,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
       assert(wrappedArticle.pubDates == Seq(LocalDate.of(2001, 2, 15)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2019, 2, 8)))
-      assert(wrappedArticle.doi == Seq("10.1038/35057062"))
+      assert(wrappedArticle.dois == Seq("10.1038/35057062"))
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
@@ -134,7 +134,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
       assert(wrappedArticle.pubDates == Seq(YearMonth.of(2006, 10)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2008, 11, 21)))
-      assert(wrappedArticle.doi == Seq("10.1080/10635150600969864"))
+      assert(wrappedArticle.dois == Seq("10.1080/10635150600969864"))
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
@@ -168,7 +168,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(wrappedArticle.allMeshTermIDs == Set())
       assert(wrappedArticle.pubDates == Seq(Year.of(2012)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2018, 11, 13)))
-      assert(wrappedArticle.doi == Seq("10.3897/zookeys.209.3247"))
+      assert(wrappedArticle.dois == Seq("10.3897/zookeys.209.3247"))
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
@@ -209,7 +209,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
       assert(wrappedArticle.pubDates == Seq(Year.of(1998)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2016, 11, 24)))
-      assert(wrappedArticle.doi == Seq())
+      assert(wrappedArticle.dois == Seq())
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -93,6 +93,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"    -> Map("blank" -> 257),
             "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
@@ -151,6 +152,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"    -> Map("blank" -> 4),
             "http://purl.org/dc/terms/references" -> Map("URI" -> 15),
@@ -181,12 +183,13 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2018, 11, 13)))
       assert(wrappedArticle.dois == Seq("10.3897/zookeys.209.3247"))
 
-      val summarizedTriples =
-        summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
+      val triples = PubMedTripleGenerator.generateTriples(wrappedArticle, None)
+      val summarizedTriples = summarizeTriples(triples)
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
             "http://purl.org/dc/terms/title"          -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"        -> Map("blank" -> 5),
             "http://purl.org/dc/terms/issued"         -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
@@ -230,6 +233,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/10542500" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"    -> Map("blank" -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -108,6 +108,15 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/pageRange" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/startingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
             )
           )
         )
@@ -171,6 +180,15 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/pageRange" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/startingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
             )
           )
         )
@@ -187,6 +205,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 <https://www.ncbi.nlm.nih.gov/pubmed/17060194>
         a                         fabio:Article ;
         prism:doi                 "10.1080/10635150600969864" ;
+        prism:endingPage          "28" ;
+        prism:pageRange           "715-28" ;
+        prism:startingPage        "715" ;
         dct:creator               ( [ a                foaf:Agent ;
                                       foaf:familyName  "Meier" ;
                                       foaf:givenName   "Rudolf"
@@ -260,6 +281,15 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/pageRange" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/startingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
             )
           )
         )
@@ -302,7 +332,16 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://purl.org/dc/terms/creator"    -> Map("blank"                                   -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#gYear"  -> 1),
-            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1)
+            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1),
+            "http://prismstandard.org/namespaces/basic/3.0/pageRange" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/startingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -219,7 +219,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         prism:endingPage           "28" ;
         prism:pageRange            "715-28" ;
         prism:startingPage         "715" ;
-        dct:bibliographicCitation  "Rudolf Meier, Kwong Shiyang, Gaurav Vaidya, Peter K L Ng. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success.. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
+        dct:bibliographicCitation  "Rudolf Meier, Kwong Shiyang, Gaurav Vaidya, Peter K L Ng. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
         dct:creator                ( [ a                foaf:Agent ;
                                        foaf:familyName  "Meier" ;
                                        foaf:givenName   "Rudolf"

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -231,7 +231,18 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         dct:modified              "2008-11-21"^^xsd:date ;
         dct:references            <http://id.nlm.nih.gov/mesh/D017422> , <http://id.nlm.nih.gov/mesh/Q000235> , <http://id.nlm.nih.gov/mesh/D004175> , <http://id.nlm.nih.gov/mesh/D000818> , <http://id.nlm.nih.gov/mesh/Q000379> , <http://id.nlm.nih.gov/mesh/D014644> , <http://id.nlm.nih.gov/mesh/D013045> , <http://id.nlm.nih.gov/mesh/D010802> , <http://id.nlm.nih.gov/mesh/Q000737> , <http://id.nlm.nih.gov/mesh/D016384> , <http://id.nlm.nih.gov/mesh/D003576> , <http://id.nlm.nih.gov/mesh/D001483> , <http://id.nlm.nih.gov/mesh/D002965> , <http://id.nlm.nih.gov/mesh/D004272> , <http://id.nlm.nih.gov/mesh/Q000145> ;
         dct:title                 "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success." ;
-        fabio:hasPublicationYear  "2006"^^xsd:gYear .
+        fabio:hasPublicationYear  "2006"^^xsd:gYear ;
+        frbr:partOf               [ a                      fabio:JournalIssue ;
+                                    prism:issueIdentifier  "5" ;
+                                    frbr:partOf            [ a             fabio:JournalVolume ;
+                                                             prism:volume  "55" ;
+                                                             frbr:partOf   [ a          fabio:JournalIssue ;
+                                                                             dct:title  "Systematic biology" ;
+                                                                             fabio:hasNLMJournalTitleAbbreviation
+                                                                                     "Syst. Biol."
+                                                                           ]
+                                                           ]
+                                  ] .
 """
 
       val foundGraph = graph.Factory.createDefaultGraph

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -46,6 +46,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(0))
 
       assert(wrappedArticle.pmid == "11237011")
+      assert(wrappedArticle.title == "Initial sequencing and analysis of the human genome.")
       assert(
         wrappedArticle.asString == "Initial sequencing and analysis of the human genome. The human genome holds an extraordinary trove of information about human development, physiology, medicine and evolution. Here we report the results of an international collaboration to produce and make freely available a draft sequence of the human genome. We also present an initial analysis of the data, describing some of the insights that can be gleaned from the sequence. Genetics, Medical CpG Islands Public Sector Gene Duplication Proteins Databases, Factual Proteome Proteins genetics Repetitive Sequences, Nucleic Acid Forecasting GC Rich Sequence Drug Industry Genes Sequence Analysis, DNA methods Humans Animals DNA Transposable Elements Private Sector Mutation Conserved Sequence Genome, Human RNA RNA genetics Evolution, Molecular Human Genome Project Chromosome Mapping Species Specificity Genetic Diseases, Inborn "
       )
@@ -90,6 +91,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
+            "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
             "http://purl.org/dc/terms/modified" -> Map(
@@ -107,6 +109,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(1))
 
       assert(wrappedArticle.pmid == "17060194")
+      assert(wrappedArticle.title == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success.")
       assert(
         wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity "
       )
@@ -138,6 +141,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
+            "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI" -> 15),
             "http://purl.org/dc/terms/issued" -> Map(
               "http://www.w3.org/2001/XMLSchema#gYearMonth" -> 1
@@ -157,6 +161,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(2))
 
       assert(wrappedArticle.pmid == "22859891")
+      assert(wrappedArticle.title == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks.")
       assert(
         wrappedArticle.asString == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks. Part diary, part scientific record, biological field notebooks often contain details necessary to understanding the location and environmental conditions existent during collecting events. Despite their clear value for (and recent use in) global change studies, the text-mining outputs from field notebooks have been idiosyncratic to specific research projects, and impossible to discover or re-use. Best practices and workflows for digitization, transcription, extraction, and integration with other sources are nascent or non-existent. In this paper, we demonstrate a workflow to generate structured outputs while also maintaining links to the original texts. The first step in this workflow was to place already digitized and transcribed field notebooks from the University of Colorado Museum of Natural History founder, Junius Henderson, on Wikisource, an open text transcription platform. Next, we created Wikisource templates to document places, dates, and taxa to facilitate annotation and wiki-linking. We then requested help from the public, through social media tools, to take advantage of volunteer efforts and energy. After three notebooks were fully annotated, content was converted into XML and annotations were extracted and cross-walked into Darwin Core compliant record sets. Finally, these recordsets were vetted, to provide valid taxon names, via a process we call \"taxonomic referencing.\" The result is identification and mobilization of 1,068 observations from three of Henderson's thirteen notebooks and a publishable Darwin Core record set for use in other analyses. Although challenges remain, this work demonstrates a feasible approach to unlock observations from field notebooks that enhances their discovery and interoperability without losing the narrative context from which those observations are drawn.\"Compose your notes as if you were writing a letter to someone a century in the future.\"Perrine and Patton (2011).  "
       )
@@ -170,6 +175,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
+            "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/issued" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
             "http://purl.org/dc/terms/modified" -> Map(
               "http://www.w3.org/2001/XMLSchema#date" -> 1
@@ -186,6 +192,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(3))
 
       assert(wrappedArticle.pmid == "10542500")
+      assert(wrappedArticle.title == "Thirty years of service.")
       assert(
         wrappedArticle.asString == "Thirty years of service.  Parkinson Disease therapy United Kingdom Humans Organizational Objectives Information Services Societies "
       )
@@ -209,9 +216,10 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/10542500" -> Map(
-            "http://purl.org/dc/terms/references" -> Map("URI"                                    -> 7),
-            "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
-            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"  -> 1)
+            "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),
+            "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#gYear"  -> 1),
+            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1)
           )
         )
       )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -119,6 +119,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://purl.org/vocab/frbr/core#partOf" -> Map(
+              "blank" -> 1
             )
           )
         )
@@ -191,6 +194,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://purl.org/vocab/frbr/core#partOf" -> Map(
+              "blank" -> 1
             )
           )
         )
@@ -201,6 +207,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         """@prefix dct:   <http://purl.org/dc/terms/> .
 @prefix fabio: <http://purl.org/spar/fabio/> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix frbr:  <http://purl.org/vocab/frbr/core#> .
 @prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
@@ -253,6 +260,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         Map(
           "dct"   -> "http://purl.org/dc/terms/",
           "fabio" -> "http://purl.org/spar/fabio/",
+          "frbr"  -> "http://purl.org/vocab/frbr/core#",
           "foaf"  -> "http://xmlns.com/foaf/0.1/",
           "xsd"   -> "http://www.w3.org/2001/XMLSchema#",
           "prism" -> "http://prismstandard.org/namespaces/basic/3.0/"
@@ -312,6 +320,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://purl.org/vocab/frbr/core#partOf" -> Map(
+              "blank" -> 1
             )
           )
         )
@@ -363,6 +374,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://prismstandard.org/namespaces/basic/3.0/endingPage" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
+            "http://purl.org/vocab/frbr/core#partOf" -> Map(
+              "blank" -> 1
             )
           )
         )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -243,8 +243,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
                                     prism:issueIdentifier  "5" ;
                                     frbr:partOf            [ a             fabio:JournalVolume ;
                                                              prism:volume  "55" ;
-                                                                             dct:title  "Systematic biology" ;
                                                              frbr:partOf   [ a           fabio:Journal ;
+                                                                             prism:issn  "1063-5157" ;
+                                                                             dct:title   "Systematic biology" ;
                                                                              fabio:hasNLMJournalTitleAbbreviation
                                                                                      "Syst. Biol."
                                                                            ]

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -83,6 +83,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
       assert(wrappedArticle.pubDates == Seq(LocalDate.of(2001, 2, 15)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2019, 2, 8)))
+      assert(wrappedArticle.doi == Seq("10.1038/35057062"))
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
@@ -91,7 +92,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
             "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
-            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1)
+            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
+            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )
@@ -125,6 +127,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
       assert(wrappedArticle.pubDates == Seq(YearMonth.of(2006, 10)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2008, 11, 21)))
+      assert(wrappedArticle.doi == Seq("10.1080/10635150600969864"))
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
@@ -135,7 +138,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://purl.org/dc/terms/issued" -> Map(
               "http://www.w3.org/2001/XMLSchema#gYearMonth" -> 1
             ),
-            "http://purl.org/dc/terms/modified" -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1)
+            "http://purl.org/dc/terms/modified" -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
+            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )
@@ -151,6 +155,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(wrappedArticle.allMeshTermIDs == Set())
       assert(wrappedArticle.pubDates == Seq(Year.of(2012)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2018, 11, 13)))
+      assert(wrappedArticle.doi == Seq("10.3897/zookeys.209.3247"))
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
@@ -158,7 +163,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
             "http://purl.org/dc/terms/issued"   -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
-            "http://purl.org/dc/terms/modified" -> Map("http://www.w3.org/2001/XMLSchema#date"  -> 1)
+            "http://purl.org/dc/terms/modified" -> Map("http://www.w3.org/2001/XMLSchema#date"  -> 1),
+            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )
@@ -184,6 +190,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
       assert(wrappedArticle.pubDates == Seq(Year.of(1998)))
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2016, 11, 24)))
+      assert(wrappedArticle.doi == Seq())
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -96,11 +96,13 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
-            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map(
+              "http://www.w3.org/2001/XMLSchema#gYear" -> 1
+            ),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
-            "http://purl.org/dc/terms/creator"    -> Map("blank" -> 257),
-            "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
-            "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
+            "http://purl.org/dc/terms/creator"    -> Map("blank"                                   -> 1),
+            "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 28),
+            "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1),
             "http://purl.org/dc/terms/modified" -> Map(
               "http://www.w3.org/2001/XMLSchema#date" -> 1
             ),
@@ -116,13 +118,13 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(1))
 
       assert(wrappedArticle.pmid == "17060194")
-      assert(wrappedArticle.title == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success.")
-      assert(wrappedArticle.authors.map(_.name) == Seq(
-        "Rudolf Meier",
-        "Kwong Shiyang",
-        "Gaurav Vaidya",
-        "Peter K L Ng"
-      ))
+      assert(
+        wrappedArticle.title == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success."
+      )
+      assert(
+        wrappedArticle.authors
+          .map(_.name) == Seq("Rudolf Meier", "Kwong Shiyang", "Gaurav Vaidya", "Peter K L Ng")
+      )
       assert(
         wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity "
       )
@@ -149,16 +151,18 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2008, 11, 21)))
       assert(wrappedArticle.dois == Seq("10.1080/10635150600969864"))
 
-      val triples = PubMedTripleGenerator.generateTriples(wrappedArticle, None)
+      val triples           = PubMedTripleGenerator.generateTriples(wrappedArticle, None)
       val summarizedTriples = summarizeTriples(triples)
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
-            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map(
+              "http://www.w3.org/2001/XMLSchema#gYear" -> 1
+            ),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
-            "http://purl.org/dc/terms/creator"    -> Map("blank" -> 4),
-            "http://purl.org/dc/terms/references" -> Map("URI" -> 15),
+            "http://purl.org/dc/terms/creator"    -> Map("blank"                                   -> 1),
+            "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 15),
             "http://purl.org/dc/terms/issued" -> Map(
               "http://www.w3.org/2001/XMLSchema#gYearMonth" -> 1
             ),
@@ -173,7 +177,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       )
 
       // Since this example is relatively small, we'll actually test all the triples.
-      val expectedTriplesAsTurtle = """@prefix dct:   <http://purl.org/dc/terms/> .
+      val expectedTriplesAsTurtle =
+        """@prefix dct:   <http://purl.org/dc/terms/> .
 @prefix fabio: <http://purl.org/spar/fabio/> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
@@ -182,18 +187,23 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 <https://www.ncbi.nlm.nih.gov/pubmed/17060194>
         a                         fabio:Article ;
         prism:doi                 "10.1080/10635150600969864" ;
-        dct:creator               [ foaf:familyName  "Vaidya" ;
-                                    foaf:givenName   "Gaurav"
-                                  ] ;
-        dct:creator               [ foaf:familyName  "Shiyang" ;
-                                    foaf:givenName   "Kwong"
-                                  ] ;
-        dct:creator               [ foaf:familyName  "Ng" ;
-                                    foaf:givenName   "Peter K L"
-                                  ] ;
-        dct:creator               [ foaf:familyName  "Meier" ;
-                                    foaf:givenName   "Rudolf"
-                                  ] ;
+        dct:creator               ( [ a                foaf:Agent ;
+                                      foaf:familyName  "Meier" ;
+                                      foaf:givenName   "Rudolf"
+                                    ]
+                                    [ a                foaf:Agent ;
+                                      foaf:familyName  "Shiyang" ;
+                                      foaf:givenName   "Kwong"
+                                    ]
+                                    [ a                foaf:Agent ;
+                                      foaf:familyName  "Vaidya" ;
+                                      foaf:givenName   "Gaurav"
+                                    ]
+                                    [ a                foaf:Agent ;
+                                      foaf:familyName  "Ng" ;
+                                      foaf:givenName   "Peter K L"
+                                    ]
+                                  ) ;
         dct:issued                "2006-10"^^xsd:gYearMonth ;
         dct:modified              "2008-11-21"^^xsd:date ;
         dct:references            <http://id.nlm.nih.gov/mesh/D017422> , <http://id.nlm.nih.gov/mesh/Q000235> , <http://id.nlm.nih.gov/mesh/D004175> , <http://id.nlm.nih.gov/mesh/D000818> , <http://id.nlm.nih.gov/mesh/Q000379> , <http://id.nlm.nih.gov/mesh/D014644> , <http://id.nlm.nih.gov/mesh/D013045> , <http://id.nlm.nih.gov/mesh/D010802> , <http://id.nlm.nih.gov/mesh/Q000737> , <http://id.nlm.nih.gov/mesh/D016384> , <http://id.nlm.nih.gov/mesh/D003576> , <http://id.nlm.nih.gov/mesh/D001483> , <http://id.nlm.nih.gov/mesh/D002965> , <http://id.nlm.nih.gov/mesh/D004272> , <http://id.nlm.nih.gov/mesh/Q000145> ;
@@ -204,17 +214,17 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val foundGraph = graph.Factory.createDefaultGraph
       triples.foreach(foundGraph.add(_))
       val stringWriter = new StringWriter()
-      val model = ModelFactory.createModelForGraph(foundGraph)
-      model.setNsPrefixes(Map(
-        "dct" -> "http://purl.org/dc/terms/",
-        "fabio" -> "http://purl.org/spar/fabio/",
-        "foaf" -> "http://xmlns.com/foaf/0.1/",
-        "xsd" -> "http://www.w3.org/2001/XMLSchema#",
-        "prism" -> "http://prismstandard.org/namespaces/basic/3.0/"
-      ).asJava)
+      val model        = ModelFactory.createModelForGraph(foundGraph)
+      model.setNsPrefixes(
+        Map(
+          "dct"   -> "http://purl.org/dc/terms/",
+          "fabio" -> "http://purl.org/spar/fabio/",
+          "foaf"  -> "http://xmlns.com/foaf/0.1/",
+          "xsd"   -> "http://www.w3.org/2001/XMLSchema#",
+          "prism" -> "http://prismstandard.org/namespaces/basic/3.0/"
+        ).asJava
+      )
       model.write(stringWriter, "Turtle")
-      println(s"1<${stringWriter.toString}>")
-      println(s"2<${expectedTriplesAsTurtle}>")
       assert(stringWriter.toString == expectedTriplesAsTurtle)
     }
 
@@ -222,7 +232,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(2))
 
       assert(wrappedArticle.pmid == "22859891")
-      assert(wrappedArticle.title == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks.")
+      assert(
+        wrappedArticle.title == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks."
+      )
       assert(
         wrappedArticle.asString == "From documents to datasets: A MediaWiki-based method of annotating and extracting species observations in century-old field notebooks. Part diary, part scientific record, biological field notebooks often contain details necessary to understanding the location and environmental conditions existent during collecting events. Despite their clear value for (and recent use in) global change studies, the text-mining outputs from field notebooks have been idiosyncratic to specific research projects, and impossible to discover or re-use. Best practices and workflows for digitization, transcription, extraction, and integration with other sources are nascent or non-existent. In this paper, we demonstrate a workflow to generate structured outputs while also maintaining links to the original texts. The first step in this workflow was to place already digitized and transcribed field notebooks from the University of Colorado Museum of Natural History founder, Junius Henderson, on Wikisource, an open text transcription platform. Next, we created Wikisource templates to document places, dates, and taxa to facilitate annotation and wiki-linking. We then requested help from the public, through social media tools, to take advantage of volunteer efforts and energy. After three notebooks were fully annotated, content was converted into XML and annotations were extracted and cross-walked into Darwin Core compliant record sets. Finally, these recordsets were vetted, to provide valid taxon names, via a process we call \"taxonomic referencing.\" The result is identification and mobilization of 1,068 observations from three of Henderson's thirteen notebooks and a publishable Darwin Core record set for use in other analyses. Although challenges remain, this work demonstrates a feasible approach to unlock observations from field notebooks that enhances their discovery and interoperability without losing the narrative context from which those observations are drawn.\"Compose your notes as if you were writing a letter to someone a century in the future.\"Perrine and Patton (2011).  "
       )
@@ -231,17 +243,19 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(wrappedArticle.revisedDates == Seq(LocalDate.of(2018, 11, 13)))
       assert(wrappedArticle.dois == Seq("10.3897/zookeys.209.3247"))
 
-      val triples = PubMedTripleGenerator.generateTriples(wrappedArticle, None)
+      val triples           = PubMedTripleGenerator.generateTriples(wrappedArticle, None)
       val summarizedTriples = summarizeTriples(triples)
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
-            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
-            "http://purl.org/dc/terms/title"          -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
-            "http://purl.org/dc/terms/creator"        -> Map("blank" -> 5),
-            "http://purl.org/dc/terms/issued"         -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
-            "http://purl.org/dc/terms/modified"       -> Map(
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map(
+              "http://www.w3.org/2001/XMLSchema#gYear" -> 1
+            ),
+            "http://purl.org/dc/terms/title"   -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://purl.org/dc/terms/creator" -> Map("blank"                                   -> 1),
+            "http://purl.org/dc/terms/issued"  -> Map("http://www.w3.org/2001/XMLSchema#gYear"  -> 1),
+            "http://purl.org/dc/terms/modified" -> Map(
               "http://www.w3.org/2001/XMLSchema#date" -> 1
             ),
             "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
@@ -281,9 +295,11 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/10542500" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
-            "http://purl.org/spar/fabio/hasPublicationYear" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
+            "http://purl.org/spar/fabio/hasPublicationYear" -> Map(
+              "http://www.w3.org/2001/XMLSchema#gYear" -> 1
+            ),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
-            "http://purl.org/dc/terms/creator"    -> Map("blank" -> 1),
+            "http://purl.org/dc/terms/creator"    -> Map("blank"                                   -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#gYear"  -> 1),
             "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1)

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -92,8 +92,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
             "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
-            "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
-            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/dc/terms/modified" -> Map(
+              "http://www.w3.org/2001/XMLSchema#date" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )
@@ -138,8 +142,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             "http://purl.org/dc/terms/issued" -> Map(
               "http://www.w3.org/2001/XMLSchema#gYearMonth" -> 1
             ),
-            "http://purl.org/dc/terms/modified" -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
-            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/dc/terms/modified" -> Map(
+              "http://www.w3.org/2001/XMLSchema#date" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )
@@ -162,9 +170,13 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
-            "http://purl.org/dc/terms/issued"   -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
-            "http://purl.org/dc/terms/modified" -> Map("http://www.w3.org/2001/XMLSchema#date"  -> 1),
-            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+            "http://purl.org/dc/terms/issued" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
+            "http://purl.org/dc/terms/modified" -> Map(
+              "http://www.w3.org/2001/XMLSchema#date" -> 1
+            ),
+            "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            )
           )
         )
       )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -94,6 +94,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
+
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
@@ -168,8 +169,14 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       val triples           = PubMedTripleGenerator.generateTriples(wrappedArticle, None)
       val summarizedTriples = summarizeTriples(triples)
+
       assert(
         summarizedTriples == Map(
+          "http://orcid.org/0000000305870454#person" -> Map(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
+            "http://xmlns.com/foaf/0.1/familyName" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://xmlns.com/foaf/0.1/givenName" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
+          ),
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
             "http://purl.org/spar/fabio/hasPublicationYear" -> Map(
@@ -213,6 +220,11 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 @prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
+<http://orcid.org/0000000305870454#person>
+        a                foaf:Agent ;
+        foaf:familyName  "Vaidya" ;
+        foaf:givenName   "Gaurav" .
+
 <https://www.ncbi.nlm.nih.gov/pubmed/17060194>
         a                          fabio:Article ;
         prism:doi                  "10.1080/10635150600969864" ;
@@ -228,10 +240,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
                                        foaf:familyName  "Shiyang" ;
                                        foaf:givenName   "Kwong"
                                      ]
-                                     [ a                foaf:Agent ;
-                                       foaf:familyName  "Vaidya" ;
-                                       foaf:givenName   "Gaurav"
-                                     ]
+                                     <http://orcid.org/0000000305870454#person>
                                      [ a                foaf:Agent ;
                                        foaf:familyName  "Ng" ;
                                        foaf:givenName   "Peter K L"

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -122,7 +122,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://purl.org/vocab/frbr/core#partOf" -> Map(
               "blank" -> 1
-            )
+            ),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )
@@ -197,7 +198,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://purl.org/vocab/frbr/core#partOf" -> Map(
               "blank" -> 1
-            )
+            ),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )
@@ -212,45 +214,46 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
 <https://www.ncbi.nlm.nih.gov/pubmed/17060194>
-        a                         fabio:Article ;
-        prism:doi                 "10.1080/10635150600969864" ;
-        prism:endingPage          "28" ;
-        prism:pageRange           "715-28" ;
-        prism:startingPage        "715" ;
-        dct:creator               ( [ a                foaf:Agent ;
-                                      foaf:familyName  "Meier" ;
-                                      foaf:givenName   "Rudolf"
-                                    ]
-                                    [ a                foaf:Agent ;
-                                      foaf:familyName  "Shiyang" ;
-                                      foaf:givenName   "Kwong"
-                                    ]
-                                    [ a                foaf:Agent ;
-                                      foaf:familyName  "Vaidya" ;
-                                      foaf:givenName   "Gaurav"
-                                    ]
-                                    [ a                foaf:Agent ;
-                                      foaf:familyName  "Ng" ;
-                                      foaf:givenName   "Peter K L"
-                                    ]
-                                  ) ;
-        dct:issued                "2006-10"^^xsd:gYearMonth ;
-        dct:modified              "2008-11-21"^^xsd:date ;
-        dct:references            <http://id.nlm.nih.gov/mesh/D017422> , <http://id.nlm.nih.gov/mesh/D004175> , <http://id.nlm.nih.gov/mesh/Q000235> , <http://id.nlm.nih.gov/mesh/D000818> , <http://id.nlm.nih.gov/mesh/Q000379> , <http://id.nlm.nih.gov/mesh/D014644> , <http://id.nlm.nih.gov/mesh/D013045> , <http://id.nlm.nih.gov/mesh/D010802> , <http://id.nlm.nih.gov/mesh/Q000737> , <http://id.nlm.nih.gov/mesh/D016384> , <http://id.nlm.nih.gov/mesh/D003576> , <http://id.nlm.nih.gov/mesh/D001483> , <http://id.nlm.nih.gov/mesh/D002965> , <http://id.nlm.nih.gov/mesh/D004272> , <http://id.nlm.nih.gov/mesh/Q000145> ;
-        dct:title                 "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success." ;
-        fabio:hasPublicationYear  "2006"^^xsd:gYear ;
-        frbr:partOf               [ a                      fabio:JournalIssue ;
-                                    prism:issueIdentifier  "5" ;
-                                    frbr:partOf            [ a             fabio:JournalVolume ;
-                                                             prism:volume  "55" ;
-                                                             frbr:partOf   [ a           fabio:Journal ;
-                                                                             prism:issn  "1063-5157" ;
-                                                                             dct:title   "Systematic biology" ;
-                                                                             fabio:hasNLMJournalTitleAbbreviation
-                                                                                     "Syst. Biol."
-                                                                           ]
-                                                           ]
-                                  ] .
+        a                          fabio:Article ;
+        prism:doi                  "10.1080/10635150600969864" ;
+        prism:endingPage           "28" ;
+        prism:pageRange            "715-28" ;
+        prism:startingPage         "715" ;
+        dct:bibliographicCitation  "Rudolf Meier, Kwong Shiyang, Gaurav Vaidya, Peter K L Ng. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success.. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
+        dct:creator                ( [ a                foaf:Agent ;
+                                       foaf:familyName  "Meier" ;
+                                       foaf:givenName   "Rudolf"
+                                     ]
+                                     [ a                foaf:Agent ;
+                                       foaf:familyName  "Shiyang" ;
+                                       foaf:givenName   "Kwong"
+                                     ]
+                                     [ a                foaf:Agent ;
+                                       foaf:familyName  "Vaidya" ;
+                                       foaf:givenName   "Gaurav"
+                                     ]
+                                     [ a                foaf:Agent ;
+                                       foaf:familyName  "Ng" ;
+                                       foaf:givenName   "Peter K L"
+                                     ]
+                                   ) ;
+        dct:issued                 "2006-10"^^xsd:gYearMonth ;
+        dct:modified               "2008-11-21"^^xsd:date ;
+        dct:references             <http://id.nlm.nih.gov/mesh/D017422> , <http://id.nlm.nih.gov/mesh/D004175> , <http://id.nlm.nih.gov/mesh/Q000235> , <http://id.nlm.nih.gov/mesh/D000818> , <http://id.nlm.nih.gov/mesh/Q000379> , <http://id.nlm.nih.gov/mesh/D014644> , <http://id.nlm.nih.gov/mesh/D013045> , <http://id.nlm.nih.gov/mesh/D010802> , <http://id.nlm.nih.gov/mesh/Q000737> , <http://id.nlm.nih.gov/mesh/D016384> , <http://id.nlm.nih.gov/mesh/D003576> , <http://id.nlm.nih.gov/mesh/D001483> , <http://id.nlm.nih.gov/mesh/D002965> , <http://id.nlm.nih.gov/mesh/D004272> , <http://id.nlm.nih.gov/mesh/Q000145> ;
+        dct:title                  "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success." ;
+        fabio:hasPublicationYear   "2006"^^xsd:gYear ;
+        frbr:partOf                [ a                      fabio:JournalIssue ;
+                                     prism:issueIdentifier  "5" ;
+                                     frbr:partOf            [ a             fabio:JournalVolume ;
+                                                              prism:volume  "55" ;
+                                                              frbr:partOf   [ a           fabio:Journal ;
+                                                                              prism:issn  "1063-5157" ;
+                                                                              dct:title   "Systematic biology" ;
+                                                                              fabio:hasNLMJournalTitleAbbreviation
+                                                                                      "Syst. Biol."
+                                                                            ]
+                                                            ]
+                                   ] .
 """
 
       val foundGraph = graph.Factory.createDefaultGraph
@@ -326,7 +329,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://purl.org/vocab/frbr/core#partOf" -> Map(
               "blank" -> 1
-            )
+            ),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )
@@ -380,7 +384,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
             ),
             "http://purl.org/vocab/frbr/core#partOf" -> Map(
               "blank" -> 1
-            )
+            ),
+            "http://purl.org/dc/terms/bibliographicCitation" -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1)
           )
         )
       )

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -92,6 +92,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"    -> Map("blank" -> 257),
             "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
@@ -150,6 +151,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"    -> Map("blank" -> 4),
             "http://purl.org/dc/terms/references" -> Map("URI" -> 15),
@@ -185,6 +187,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
             "http://purl.org/dc/terms/title"          -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"        -> Map("blank" -> 5),
             "http://purl.org/dc/terms/issued"         -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
@@ -227,6 +230,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/10542500" -> Map(
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://purl.org/dc/terms/creator"    -> Map("blank" -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -147,7 +147,6 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
-      println(summarizedTriples)
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -29,6 +29,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
     //   ...
     // )
     triples
+      .filter(!_.getSubject.isBlank) // Remove blank nodes.
       .groupBy(_.getSubject.getURI)
       .mapValues(_.groupBy(_.getPredicate.getURI).mapValues(triples => {
         (triples.toSeq map { triple: graph.Triple =>
@@ -92,6 +93,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/11237011" -> Map(
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://purl.org/dc/terms/creator"    -> Map("blank" -> 257),
             "http://purl.org/dc/terms/references" -> Map("URI"                                   -> 28),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#date" -> 1),
             "http://purl.org/dc/terms/modified" -> Map(
@@ -110,6 +112,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       assert(wrappedArticle.pmid == "17060194")
       assert(wrappedArticle.title == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success.")
+      assert(wrappedArticle.authors.map(_.name) == Seq(
+        "Rudolf Meier",
+        "Kwong Shiyang",
+        "Gaurav Vaidya",
+        "Peter K L Ng"
+      ))
       assert(
         wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity "
       )
@@ -138,10 +146,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       val summarizedTriples =
         summarizeTriples(PubMedTripleGenerator.generateTriples(wrappedArticle, None))
+      println(summarizedTriples)
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/17060194" -> Map(
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://purl.org/dc/terms/creator"    -> Map("blank" -> 4),
             "http://purl.org/dc/terms/references" -> Map("URI" -> 15),
             "http://purl.org/dc/terms/issued" -> Map(
               "http://www.w3.org/2001/XMLSchema#gYearMonth" -> 1
@@ -175,9 +185,10 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/22859891" -> Map(
-            "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
-            "http://purl.org/dc/terms/issued" -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
-            "http://purl.org/dc/terms/modified" -> Map(
+            "http://purl.org/dc/terms/title"          -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://purl.org/dc/terms/creator"        -> Map("blank" -> 5),
+            "http://purl.org/dc/terms/issued"         -> Map("http://www.w3.org/2001/XMLSchema#gYear" -> 1),
+            "http://purl.org/dc/terms/modified"       -> Map(
               "http://www.w3.org/2001/XMLSchema#date" -> 1
             ),
             "http://prismstandard.org/namespaces/basic/3.0/doi" -> Map(
@@ -217,6 +228,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "https://www.ncbi.nlm.nih.gov/pubmed/10542500" -> Map(
             "http://purl.org/dc/terms/title"      -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
+            "http://purl.org/dc/terms/creator"    -> Map("blank" -> 1),
             "http://purl.org/dc/terms/references" -> Map("URI"                                     -> 7),
             "http://purl.org/dc/terms/issued"     -> Map("http://www.w3.org/2001/XMLSchema#gYear"  -> 1),
             "http://purl.org/dc/terms/modified"   -> Map("http://www.w3.org/2001/XMLSchema#date"   -> 1)

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -1,10 +1,11 @@
 package org.renci.chemotext
 
-import java.io.{StringReader, StringWriter}
+import java.io.{ByteArrayOutputStream, StringReader, StringWriter}
 import java.time.{LocalDate, Year, YearMonth}
 
 import org.apache.jena.graph
 import org.apache.jena.rdf.model.{Property, ResourceFactory, Statement, ModelFactory}
+import org.apache.jena.riot.{RDFWriter, RDFFormat}
 import utest._
 
 import collection.mutable
@@ -245,8 +246,17 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
           "prism" -> "http://prismstandard.org/namespaces/basic/3.0/"
         ).asJava
       )
-      model.write(stringWriter, "Turtle")
-      assert(stringWriter.toString == expectedTriplesAsTurtle)
+      val baos = new ByteArrayOutputStream()
+      RDFWriter.create.source(model).format(RDFFormat.TURTLE).output(baos);
+
+      val actual = baos.toString("UTF-8").split("\n")
+      val expected = expectedTriplesAsTurtle.split("\n")
+
+      (0 until max(expected.length, actual.length)).foreach(x => {
+        val actualLine = actual(x)
+        val expectLine = expected(x)
+        assert(actualLine == expectLine)
+      })
     }
 
     test("An example with year only") {

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -236,7 +236,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
                                   ) ;
         dct:issued                "2006-10"^^xsd:gYearMonth ;
         dct:modified              "2008-11-21"^^xsd:date ;
-        dct:references            <http://id.nlm.nih.gov/mesh/D017422> , <http://id.nlm.nih.gov/mesh/Q000235> , <http://id.nlm.nih.gov/mesh/D004175> , <http://id.nlm.nih.gov/mesh/D000818> , <http://id.nlm.nih.gov/mesh/Q000379> , <http://id.nlm.nih.gov/mesh/D014644> , <http://id.nlm.nih.gov/mesh/D013045> , <http://id.nlm.nih.gov/mesh/D010802> , <http://id.nlm.nih.gov/mesh/Q000737> , <http://id.nlm.nih.gov/mesh/D016384> , <http://id.nlm.nih.gov/mesh/D003576> , <http://id.nlm.nih.gov/mesh/D001483> , <http://id.nlm.nih.gov/mesh/D002965> , <http://id.nlm.nih.gov/mesh/D004272> , <http://id.nlm.nih.gov/mesh/Q000145> ;
+        dct:references            <http://id.nlm.nih.gov/mesh/D017422> , <http://id.nlm.nih.gov/mesh/D004175> , <http://id.nlm.nih.gov/mesh/Q000235> , <http://id.nlm.nih.gov/mesh/D000818> , <http://id.nlm.nih.gov/mesh/Q000379> , <http://id.nlm.nih.gov/mesh/D014644> , <http://id.nlm.nih.gov/mesh/D013045> , <http://id.nlm.nih.gov/mesh/D010802> , <http://id.nlm.nih.gov/mesh/Q000737> , <http://id.nlm.nih.gov/mesh/D016384> , <http://id.nlm.nih.gov/mesh/D003576> , <http://id.nlm.nih.gov/mesh/D001483> , <http://id.nlm.nih.gov/mesh/D002965> , <http://id.nlm.nih.gov/mesh/D004272> , <http://id.nlm.nih.gov/mesh/Q000145> ;
         dct:title                 "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success." ;
         fabio:hasPublicationYear  "2006"^^xsd:gYear ;
         frbr:partOf               [ a                      fabio:JournalIssue ;
@@ -268,10 +268,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         ).asJava
       )
       val baos = new ByteArrayOutputStream()
-      RDFWriter.create.source(model).format(RDFFormat.TURTLE).output(baos);
+      RDFWriter.create.source(model).format(RDFFormat.TURTLE_PRETTY).output(baos);
 
       val actual = baos.toString("UTF-8").split("\n")
       val expected = expectedTriplesAsTurtle.split("\n")
+
+      // assert(baos.toString("UTF-8") == expectedTriplesAsTurtle)
 
       (0 until max(expected.length, actual.length)).foreach(x => {
         val actualLine = actual(x)


### PR DESCRIPTION
This PR adds support for exporting journal metadata (closes #29) and adds tests for verifying that the correct triples are being generated (closes #17).

It also updates Apache Jena from 3.2.0 to 3.13.1. 