### PR TITLE
Added support for "et al", collective names and suffixes.

### DIFF
--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -58,18 +58,22 @@ class AuthorWrapper(node: Node) {
   val familyName: String = {
     if (suffix.isEmpty) lastName else s"$lastName $suffix"
   }
-  val name: String      = if (!collectiveName.isEmpty) collectiveName else s"$givenName $familyName"
-  val shortName: String = if (!collectiveName.isEmpty) collectiveName else {
-    if (suffix.isEmpty) {
-      if (initials.isEmpty) lastName else s"$lastName $initials"
-    } else {
-      if (initials.isEmpty) s"$lastName $suffix" else s"$lastName $initials $suffix"
+  val name: String = if (!collectiveName.isEmpty) collectiveName else s"$givenName $familyName"
+  val shortName: String =
+    if (!collectiveName.isEmpty) collectiveName
+    else {
+      if (suffix.isEmpty) {
+        if (initials.isEmpty) lastName else s"$lastName $initials"
+      } else {
+        if (initials.isEmpty) s"$lastName $suffix" else s"$lastName $initials $suffix"
+      }
     }
-  }
 }
 
 object AuthorWrapper {
-  val ET_AL: AuthorWrapper = new AuthorWrapper(<Author><CollectiveName>et al</CollectiveName></Author>)
+  val ET_AL: AuthorWrapper = new AuthorWrapper(
+    <Author><CollectiveName>et al</CollectiveName></Author>
+  )
 }
 
 /** An object containing code for working with PubMed articles. */
@@ -397,14 +401,17 @@ object PubMedTripleGenerator {
     val authorModel = ModelFactory.createDefaultModel
     val authorResources = pubMedArticleWrapped.authors.map({ author =>
       // If we have an ORCID for this author, use that to create a URL for this author. Otherwise, leave it as a blank node.
-      val authorResource =  if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent) else
+      val authorResource =
+        if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent)
+        else
           authorModel.createResource(
             s"http://orcid.org/${author.orcIds.headOption.getOrElse("")}#person",
             FOAF.Agent
           )
 
       if (author.collectiveName.isEmpty) {
-        authorResource.addProperty(
+        authorResource
+          .addProperty(
             ResourceFactory.createProperty(s"$FOAFNamespace/name"),
             ResourceFactory.createTypedLiteral(author.name, XSDDatatype.XSDstring)
           )

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -59,11 +59,17 @@ class AuthorWrapper(node: Node) {
     if (suffix.isEmpty) lastName else s"$lastName $suffix"
   }
   val name: String      = if (!collectiveName.isEmpty) collectiveName else s"$givenName $familyName"
-  val shortName: String = if (initials.isEmpty) lastName else s"$lastName $initials"
+  val shortName: String = if (!collectiveName.isEmpty) collectiveName else {
+    if (suffix.isEmpty) {
+      if (initials.isEmpty) lastName else s"$lastName $initials"
+    } else {
+      if (initials.isEmpty) s"$lastName $suffix" else s"$lastName $initials $suffix"
+    }
+  }
 }
 
 object AuthorWrapper {
-  val ET_AL: AuthorWrapper = new AuthorWrapper(<Author><LastName>et al.</LastName></Author>)
+  val ET_AL: AuthorWrapper = new AuthorWrapper(<Author><CollectiveName>et al</CollectiveName></Author>)
 }
 
 /** An object containing code for working with PubMed articles. */
@@ -390,15 +396,19 @@ object PubMedTripleGenerator {
 
     val authorModel = ModelFactory.createDefaultModel
     val authorResources = pubMedArticleWrapped.authors.map({ author =>
-      (
-        // If we have an ORCID for this author, use that to create a URL for this author. Otherwise, leave it as a blank node.
-        if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent)
-        else
+      // If we have an ORCID for this author, use that to create a URL for this author. Otherwise, leave it as a blank node.
+      val authorResource =  if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent) else
           authorModel.createResource(
             s"http://orcid.org/${author.orcIds.headOption.getOrElse("")}#person",
             FOAF.Agent
           )
-      ).addProperty(
+
+      if (author.collectiveName.isEmpty) {
+        authorResource.addProperty(
+          ResourceFactory.createProperty(s"$FOAFNamespace/name"),
+          ResourceFactory.createTypedLiteral(author.name, XSDDatatype.XSDstring)
+        )
+        authorResource.addProperty(
           ResourceFactory.createProperty(s"$FOAFNamespace/familyName"),
           ResourceFactory.createTypedLiteral(author.familyName, XSDDatatype.XSDstring)
         )
@@ -406,6 +416,12 @@ object PubMedTripleGenerator {
           ResourceFactory.createProperty(s"$FOAFNamespace/givenName"),
           ResourceFactory.createTypedLiteral(author.givenName, XSDDatatype.XSDstring)
         )
+      } else {
+        authorResource.addProperty(
+          ResourceFactory.createProperty(s"$FOAFNamespace/name"),
+          ResourceFactory.createTypedLiteral(author.collectiveName, XSDDatatype.XSDstring)
+        )
+      }
     })
     val authorRDFList = authorModel.createList(authorResources.iterator.asJava)
     val authorStatements = authorModel.listStatements.toList.asScala :+ ResourceFactory

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -405,17 +405,17 @@ object PubMedTripleGenerator {
 
       if (author.collectiveName.isEmpty) {
         authorResource.addProperty(
-          ResourceFactory.createProperty(s"$FOAFNamespace/name"),
-          ResourceFactory.createTypedLiteral(author.name, XSDDatatype.XSDstring)
-        )
-        authorResource.addProperty(
-          ResourceFactory.createProperty(s"$FOAFNamespace/familyName"),
-          ResourceFactory.createTypedLiteral(author.familyName, XSDDatatype.XSDstring)
-        )
-        .addProperty(
-          ResourceFactory.createProperty(s"$FOAFNamespace/givenName"),
-          ResourceFactory.createTypedLiteral(author.givenName, XSDDatatype.XSDstring)
-        )
+            ResourceFactory.createProperty(s"$FOAFNamespace/name"),
+            ResourceFactory.createTypedLiteral(author.name, XSDDatatype.XSDstring)
+          )
+          .addProperty(
+            ResourceFactory.createProperty(s"$FOAFNamespace/familyName"),
+            ResourceFactory.createTypedLiteral(author.familyName, XSDDatatype.XSDstring)
+          )
+          .addProperty(
+            ResourceFactory.createProperty(s"$FOAFNamespace/givenName"),
+            ResourceFactory.createTypedLiteral(author.givenName, XSDDatatype.XSDstring)
+          )
       } else {
         authorResource.addProperty(
           ResourceFactory.createProperty(s"$FOAFNamespace/name"),

--- a/src/test/resources/pubmedXML/examplesForTests.xml
+++ b/src/test/resources/pubmedXML/examplesForTests.xml
@@ -1538,7 +1538,8 @@
               <Abstract>
                   <AbstractText>DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (&quot;DNA barcoding&quot;) and find a relatively low success rate (&lt; 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy.</AbstractText>
               </Abstract>
-              <AuthorList CompleteYN="Y">
+              <!-- This AuthorList differs from the actual PMID entry so we can test multiple PubMed features. -->
+              <AuthorList CompleteYN="N">
                   <Author ValidYN="Y">
                       <LastName>Meier</LastName>
                       <ForeName>Rudolf</ForeName>
@@ -1556,6 +1557,7 @@
                       <LastName>Vaidya</LastName>
                       <ForeName>Gaurav</ForeName>
                       <Initials>G</Initials>
+                      <Suffix>Jr</Suffix>
                       <Identifier Source="ORCID">0000000305870454</Identifier>
                   </Author>
                   <Author ValidYN="Y">

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -138,7 +138,15 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         wrappedArticle.title == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success."
       )
       val authorNames = wrappedArticle.authors.map(_.name)
-      assert(authorNames == Seq("Rudolf Meier", "Kwong Shiyang", "Gaurav Vaidya Jr", "Peter K L Ng", "et al"))
+      assert(
+        authorNames == Seq(
+          "Rudolf Meier",
+          "Kwong Shiyang",
+          "Gaurav Vaidya Jr",
+          "Peter K L Ng",
+          "et al"
+        )
+      )
       assert(
         wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity "
       )
@@ -171,10 +179,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         summarizedTriples == Map(
           "http://orcid.org/0000000305870454#person" -> Map(
-            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
-            "http://xmlns.com/foaf/0.1/name" -> Map(
-              "http://www.w3.org/2001/XMLSchema#string" -> 1
-            ),
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI"                                     -> 1),
+            "http://xmlns.com/foaf/0.1/name"                  -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://xmlns.com/foaf/0.1/familyName" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -137,10 +137,8 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       assert(
         wrappedArticle.title == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success."
       )
-      assert(
-        wrappedArticle.authors
-          .map(_.name) == Seq("Rudolf Meier", "Kwong Shiyang", "Gaurav Vaidya", "Peter K L Ng")
-      )
+      val authorNames = wrappedArticle.authors.map(_.name)
+      assert(authorNames == Seq("Rudolf Meier", "Kwong Shiyang", "Gaurav Vaidya Jr", "Peter K L Ng", "et al"))
       assert(
         wrappedArticle.asString == "DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. DNA barcoding and DNA taxonomy have recently been proposed as solutions to the crisis of taxonomy and received significant attention from scientific journals, grant agencies, natural history museums, and mainstream media. Here, we test two key claims of molecular taxonomy using 1333 mitochondrial COI sequences for 449 species of Diptera. We investigate whether sequences can be used for species identification (\"DNA barcoding\") and find a relatively low success rate (< 70%) based on tree-based and newly proposed species identification criteria. Misidentifications are due to wide overlap between intra- and interspecific genetic variability, which causes 6.5% of all query sequences to have allospecific or a mixture of allo- and conspecific (3.6%) best-matching barcodes. Even when two COI sequences are identical, there is a 6% chance that they belong to different species. We also find that 21% of all species lack unique barcodes when consensus sequences of all conspecific sequences are used. Lastly, we test whether DNA sequences yield an unambiguous species-level taxonomy when sequence profiles are assembled based on pairwise distance thresholds. We find many sequence triplets for which two of the three pairwise distances remain below the threshold, whereas the third exceeds it; i.e., it is impossible to consistently delimit species based on pairwise distances. Furthermore, for species profiles based on a 3% threshold, only 47% of all profiles are consistent with currently accepted species limits, 20% contain more than one species, and 33% only some sequences from one species; i.e., adopting such a DNA taxonomy would require the redescription of a large proportion of the known species, thus worsening the taxonomic impediment. We conclude with an outlook on the prospects of obtaining complete barcode databases and the future use of DNA sequences in a modern integrative taxonomy. Electron Transport Complex IV DNA, Mitochondrial Sequence Analysis, DNA DNA, Mitochondrial chemistry Animals Electron Transport Complex IV chemistry genetics Base Sequence Genetic Variation Classification methods Diptera classification genetics Phylogeny Consensus Sequence Species Specificity "
       )
@@ -174,6 +172,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         summarizedTriples == Map(
           "http://orcid.org/0000000305870454#person" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI" -> 1),
+            "http://xmlns.com/foaf/0.1/name" -> Map(
+              "http://www.w3.org/2001/XMLSchema#string" -> 1
+            ),
             "http://xmlns.com/foaf/0.1/familyName" -> Map(
               "http://www.w3.org/2001/XMLSchema#string" -> 1
             ),
@@ -226,8 +227,9 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
 <http://orcid.org/0000000305870454#person>
         a                foaf:Agent ;
-        foaf:familyName  "Vaidya" ;
-        foaf:givenName   "Gaurav" .
+        foaf:familyName  "Vaidya Jr" ;
+        foaf:givenName   "Gaurav" ;
+        foaf:name        "Gaurav Vaidya Jr" .
 
 <https://www.ncbi.nlm.nih.gov/pubmed/17060194>
         a                          fabio:Article ;
@@ -235,19 +237,25 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         prism:endingPage           "28" ;
         prism:pageRange            "715-28" ;
         prism:startingPage         "715" ;
-        dct:bibliographicCitation  "Meier R, Shiyang K, Vaidya G, Ng PK. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
+        dct:bibliographicCitation  "Meier R, Shiyang K, Vaidya G Jr, Ng PK, et al. DNA barcoding and taxonomy in Diptera: a tale of high intraspecific variability and low identification success. Systematic biology (2006);55(5):715-28. PubMed PMID: 17060194" ;
         dct:creator                ( [ a                foaf:Agent ;
                                        foaf:familyName  "Meier" ;
-                                       foaf:givenName   "Rudolf"
+                                       foaf:givenName   "Rudolf" ;
+                                       foaf:name        "Rudolf Meier"
                                      ]
                                      [ a                foaf:Agent ;
                                        foaf:familyName  "Shiyang" ;
-                                       foaf:givenName   "Kwong"
+                                       foaf:givenName   "Kwong" ;
+                                       foaf:name        "Kwong Shiyang"
                                      ]
                                      <http://orcid.org/0000000305870454#person>
                                      [ a                foaf:Agent ;
                                        foaf:familyName  "Ng" ;
-                                       foaf:givenName   "Peter K L"
+                                       foaf:givenName   "Peter K L" ;
+                                       foaf:name        "Peter K L Ng"
+                                     ]
+                                     [ a          foaf:Agent ;
+                                       foaf:name  "et al"
                                      ]
                                    ) ;
         dct:issued                 "2006-10"^^xsd:gYearMonth ;


### PR DESCRIPTION
This PR improves name generation by:
1. Including `foaf:name` for all names
2. Supporting the use of collective names as opposed to lastName/firstName combinations
3. Implementing `et al` as a collective name so we don't get extra spaces before the name
4. Added support for suffixes in short names