### PR TITLE
Add logging

### DIFF
--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -383,6 +383,8 @@ object Main extends App with LazyLogging {
     // Generate triples for all wrapped PubMed articles.
     @SuppressWarnings(Array("org.wartremover.warts.Var"))
     var tripleCount = 0
+    @SuppressWarnings(Array("org.wartremover.warts.Var"))
+    var articleCount = 0
     val done = Source(wrappedArticles)
       .mapAsyncUnordered(parallelism) { article: PubMedArticleWrapper =>
         Future {
@@ -390,11 +392,12 @@ object Main extends App with LazyLogging {
         }
       }
       .runForeach { triples =>
+        articleCount += 1
         tripleCount += triples.size
         StreamRDFOps.sendTriplesToStream(triples.iterator.asJava, rdfStream)
         if (tripleCount % 100 == 0)
           logger.info(
-            s"Approximately %,d triples have been added to the output stream.".format(tripleCount)
+            s"Approximately %,d triples added from %,d articles in %s.".format(tripleCount, articleCount, file)
           )
       }
 

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -69,6 +69,7 @@ object PubMedTripleGenerator extends LazyLogging {
   val FRBRNamespace       = "http://purl.org/vocab/frbr/core"
 
   // Extract dates as RDF statements.
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def convertDatesToTriples(pmidIRI: Resource, property: Property)(
     date: Try[TemporalAccessor]
   ): Option[Statement] = {

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -437,7 +437,13 @@ object Main extends App with LazyLogging {
 
     // Write out the time taken for processing.
     val duration = Duration.ofNanos(System.nanoTime - startTime)
-    logger.info(s"Done processing $file in $duration")
+    logger.info("Took %d seconds (%s) to create approx %,d triples from %,d articles in %s".format(
+      duration.getSeconds,
+      duration.toString,
+      tripleCount,
+      wrappedArticles.size,
+      file
+    ))
   }
   terminateAkka()
 }

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import utest._
 
 import sys.process._
+import scala.util.matching.Regex
 
 /**
   * Tests for the entire Omnicorp application.
@@ -25,7 +26,8 @@ object OmnicorpTests extends TestSuite {
   }
 
   // Regex for matching the final result line in STDERR.
-  val finalResultRegex = "Took \\d+ seconds (.*) to create approx [\\d,]+ triples from [\\d,]+ articles in .*".r
+  val finalResultRegex: Regex =
+    "Took \\d+ seconds (.*) to create approx [\\d,]+ triples from [\\d,]+ articles in .*".r
 
   val tests: Tests = Tests {
     test("Make sure we can run Omnicorp and see runtime information") {
@@ -41,7 +43,8 @@ object OmnicorpTests extends TestSuite {
       val tmpFolder        = Files.createTempDirectory("omnicorp-testing").toFile
 
       test("Make sure we can execute Omnicorp on the example file") {
-        val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
+        val (status, stdout, stderr) =
+          exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
 
         // Clean up temporary folder.
         val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
@@ -63,7 +66,8 @@ object OmnicorpTests extends TestSuite {
       val tmpFolder       = Files.createTempDirectory("omnicorp-testing").toFile
 
       test("Make sure we get a warning message on executing Omnicorp on this example file") {
-        val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1"""))
+        val (status, stdout, stderr) =
+          exec(Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1"""))
 
         // Clean up temporary folder.
         val outputFile = new File(tmpFolder, "failedExamples1.xml.ttl")
@@ -77,7 +81,9 @@ object OmnicorpTests extends TestSuite {
 
         assert(stderr contains "Begin processing")
         assert(stderr contains "WARN org.renci.chemotext.PubMedTripleGenerator")
-        assert(stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>")
+        assert(
+          stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>"
+        )
         assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
       }
     }

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -1,6 +1,5 @@
 package org.renci.chemotext
 
-import scala.io.Source
 import java.io.File
 import java.nio.file.Files
 
@@ -44,14 +43,8 @@ object OmnicorpTests extends TestSuite {
       test("Make sure we can execute Omnicorp on the example file") {
         val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
 
-        // Make sure that the output file has triples indicating completion.
-        val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
-        val outputBuffer = Source.fromFile(outputFile)
-        val output = outputBuffer.getLines().mkString("\n")
-        assert(output contains "")
-        outputBuffer.close()
-
         // Clean up temporary folder.
+        val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
         outputFile.delete()
         tmpFolder.delete()
 

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -25,6 +25,9 @@ object OmnicorpTests extends TestSuite {
     (status, stdout.toString, stderr.toString)
   }
 
+  // Regex for matching the final result line in STDERR.
+  val finalResultRegex = "Took \\d+ seconds (.*) to create approx [\\d,]+ triples from [\\d,]+ articles in .*".r
+
   val tests: Tests = Tests {
     test("Make sure we can run Omnicorp and see runtime information") {
       val (status, stdout, stderr) = exec(Seq("sbt", "run"))
@@ -58,7 +61,7 @@ object OmnicorpTests extends TestSuite {
         assert(stdout contains "completed")
 
         assert(stderr contains "Begin processing")
-        assert(stderr contains "Done processing")
+        assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
       }
     }
 
@@ -82,7 +85,7 @@ object OmnicorpTests extends TestSuite {
         assert(stderr contains "Begin processing")
         assert(stderr contains "WARN org.renci.chemotext.PubMedTripleGenerator")
         assert(stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>")
-        assert(stderr contains "Done processing")
+        assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
       }
     }
   }

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -45,6 +45,12 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
       }))
   }
 
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.NonUnitStatements", // We need them to write to strings in memory.
+      "org.wartremover.warts.Null"               // We need them to use StringReader.
+    )
+  )
   val tests: Tests = Tests {
     test("An example with day, month and year") {
       val wrappedArticle = new PubMedArticleWrapper(pubmedArticles(0))


### PR DESCRIPTION
This PR adds three types of logging:
1. We use the logger to record on STDERR how many triples have been produced, allowing us to check that long-running jobs are have reached the triple-producing stage of processing.
2. Once processing has completed, we log to STDERR the time taken to process the job, count the number of triples being produced, and the number of articles processed.
3. We also write the time taken, number of triples and number of articles into the output Turtle file as well.

This should be merged after PR #45 has been merged.