### PR TITLE
Improve regex for MedlineDate to handle dates with the year at the end

### DIFF
--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -88,7 +88,7 @@ object PubMedArticleWrapper {
       // MedlineDates have different forms (e.g. "1989 Dec-1999 Jan", "2000 Spring", "2000 Dec 23-30").
       // For now, we check to see if it starts with four digits, suggesting an year.
       // See https://www.nlm.nih.gov/bsd/licensee/elements_descriptions.html#medlinedate for more details.
-      val medlineDateYearMatcher = """^\s*(\d{4})\b.*$""".r
+      val medlineDateYearMatcher = """^.*?\b(\d{4})\b.*$""".r
       val medlineDate            = (date \\ "MedlineDate").text
       medlineDate match {
         case medlineDateYearMatcher(year) => Success(Year.of(year.toInt))

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -10,10 +10,12 @@ import scala.xml.XML
 /**
   * Unit tests for the PubMedArticleWrapper class.
   */
-@SuppressWarnings(Array(
-  "org.wartremover.warts.TryPartial",         // We use Try.get() in a
-  "org.wartremover.warts.NonUnitStatements"   // non-unit statements to test whether parsing fails correctly.
-))
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.TryPartial",       // We use Try.get() in a
+    "org.wartremover.warts.NonUnitStatements" // non-unit statements to test whether parsing fails correctly.
+  )
+)
 object PubMedArticleWrapperUnitTests extends TestSuite {
   val tests = Tests {
     test("#parseDate") {

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -10,6 +10,10 @@ import scala.xml.XML
 /**
   * Unit tests for the PubMedArticleWrapper class.
   */
+@SuppressWarnings(Array(
+  "org.wartremover.warts.TryPartial",         // We use Try.get() in a
+  "org.wartremover.warts.NonUnitStatements"   // non-unit statements to test whether parsing fails correctly.
+))
 object PubMedArticleWrapperUnitTests extends TestSuite {
   val tests = Tests {
     test("#parseDate") {
@@ -25,7 +29,8 @@ object PubMedArticleWrapperUnitTests extends TestSuite {
           (
             LocalDate.of(2006, 10, 21),
             <PubDate><Year>2006</Year><Day>21</Day><Month>10</Month></PubDate>
-          )
+          ),
+          (Year.of(2016), <PubDate><MedlineDate>Summer 2016</MedlineDate></PubDate>)
         )
 
         datesTested.foreach({


### PR DESCRIPTION
Some dates (e.g. "Summer 2016") has the year at the end, rather than the beginning, of the MedlineDate. I've modified the regex to support those.

This should be merged after PR #33.