### PR TITLE
Add /results to .gitignore so we can store output files there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ ontologies-merged.ttl
 # Ignore input and output directories.
 /pubmed-annual-baseline
 /output
+/results
 
 # Ignore robot.
 /robot


### PR DESCRIPTION
This gives us a directory to write output, log and analysis files to.