### PR TITLE
Correct behavior for exceptions thrown during processing

### DIFF
--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -78,10 +78,8 @@ object PubMedTripleGenerator extends LazyLogging {
         logger.warn(s"Unable to parse date $property on $pmidIRI: ${err.getMessage}")
         None
       }
-      case Success(ta: TemporalAccessor) => Some(ResourceFactory.createStatement(
-        pmidIRI,
-        property,
-        ta match {
+      case Success(ta: TemporalAccessor) =>
+        Some(ResourceFactory.createStatement(pmidIRI, property, ta match {
           case localDate: LocalDate =>
             ResourceFactory.createTypedLiteral(localDate.toString, XSDDatatype.XSDdate)
           case yearMonth: YearMonth =>
@@ -90,8 +88,7 @@ object PubMedTripleGenerator extends LazyLogging {
             ResourceFactory.createTypedLiteral(year.toString, XSDDatatype.XSDgYear)
           case _ =>
             throw new RuntimeException(s"Unexpected temporal accessor found by parsing date: $ta")
-        }
-      ))
+        }))
     }
   }
 
@@ -283,19 +280,19 @@ object PubMedTripleGenerator extends LazyLogging {
 
     val dateStatements: Seq[Statement] = (
       (pubMedArticleWrapped.pubDatesParseResults map convertDatesToTriples(pmidIRI, DCTerms.issued)) ++
-      (pubMedArticleWrapped.revisedDatesParseResults map convertDatesToTriples(
-        pmidIRI,
-        DCTerms.modified
-      ))
+        (pubMedArticleWrapped.revisedDatesParseResults map convertDatesToTriples(
+          pmidIRI,
+          DCTerms.modified
+        ))
     ).flatten
 
     val metadataStatements = publicationMetadataStatements ++
       authorStatements ++
       dateStatements :+ ResourceFactory.createStatement(
-        pmidIRI,
-        DCTerms.bibliographicCitation,
-        ResourceFactory.createStringLiteral(citationString)
-      )
+      pmidIRI,
+      DCTerms.bibliographicCitation,
+      ResourceFactory.createStringLiteral(citationString)
+    )
 
     // Extract meshIRIs as RDF statements.
     val meshIRIs = pubMedArticleWrapped.allMeshTermIDs map (

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -69,6 +69,7 @@ object PubMedTripleGenerator extends LazyLogging {
   val FRBRNamespace       = "http://purl.org/vocab/frbr/core"
 
   // Extract dates as RDF statements.
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def convertDatesToTriples(pmidIRI: Resource, property: Property)(
     date: Try[TemporalAccessor]
   ): Option[Statement] = {

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -60,7 +60,7 @@ class Annotator(neo4jLocation: String) {
 }
 
 /** Methods for generating an RDF description of a PubMedArticleWrapper. */
-object PubMedTripleGenerator {
+object PubMedTripleGenerator extends LazyLogging {
   // Some namespaces.
   val MESHNamespace       = "http://id.nlm.nih.gov/mesh"
   val PRISMBasicNamespace = "http://prismstandard.org/namespaces/basic/3.0"
@@ -69,25 +69,29 @@ object PubMedTripleGenerator {
   val FRBRNamespace       = "http://purl.org/vocab/frbr/core"
 
   // Extract dates as RDF statements.
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def convertDatesToTriples(pmidIRI: Resource, property: Property)(
     date: Try[TemporalAccessor]
-  ): Statement = {
-    ResourceFactory.createStatement(
-      pmidIRI,
-      property,
-      date match {
-        case Success(localDate: LocalDate) =>
-          ResourceFactory.createTypedLiteral(localDate.toString, XSDDatatype.XSDdate)
-        case Success(yearMonth: YearMonth) =>
-          ResourceFactory.createTypedLiteral(yearMonth.toString, XSDDatatype.XSDgYearMonth)
-        case Success(year: Year) =>
-          ResourceFactory.createTypedLiteral(year.toString, XSDDatatype.XSDgYear)
-        case Success(ta: TemporalAccessor) =>
-          throw new RuntimeException(s"Unexpected temporal accessor found by parsing date: $ta")
-        case Failure(error: Throwable) => throw error
+  ): Option[Statement] = {
+    date match {
+      case Failure(err: Throwable) => {
+        logger.warn(s"Unable to parse date $property on $pmidIRI: ${err.getMessage}")
+        None
       }
-    )
+      case Success(ta: TemporalAccessor) => Some(ResourceFactory.createStatement(
+        pmidIRI,
+        property,
+        ta match {
+          case localDate: LocalDate =>
+            ResourceFactory.createTypedLiteral(localDate.toString, XSDDatatype.XSDdate)
+          case yearMonth: YearMonth =>
+            ResourceFactory.createTypedLiteral(yearMonth.toString, XSDDatatype.XSDgYearMonth)
+          case year: Year =>
+            ResourceFactory.createTypedLiteral(year.toString, XSDDatatype.XSDgYear)
+          case _ =>
+            throw new RuntimeException(s"Unexpected temporal accessor found by parsing date: $ta")
+        }
+      ))
+    }
   }
 
   /** Generate the triples for a particular PubMed article. */
@@ -276,17 +280,21 @@ object PubMedTripleGenerator {
     val citationString =
       s"$authorString. $titleString $journalTitle ($pubYear);$journalVolume$journalIssue:$journalPages. PubMed PMID: $pmid"
 
-    val metadataStatements = publicationMetadataStatements ++
-      authorStatements ++
+    val dateStatements: Seq[Statement] = (
       (pubMedArticleWrapped.pubDatesParseResults map convertDatesToTriples(pmidIRI, DCTerms.issued)) ++
       (pubMedArticleWrapped.revisedDatesParseResults map convertDatesToTriples(
         pmidIRI,
         DCTerms.modified
-      )) :+ ResourceFactory.createStatement(
-      pmidIRI,
-      DCTerms.bibliographicCitation,
-      ResourceFactory.createStringLiteral(citationString)
-    )
+      ))
+    ).flatten
+
+    val metadataStatements = publicationMetadataStatements ++
+      authorStatements ++
+      dateStatements :+ ResourceFactory.createStatement(
+        pmidIRI,
+        DCTerms.bibliographicCitation,
+        ResourceFactory.createStringLiteral(citationString)
+      )
 
     // Extract meshIRIs as RDF statements.
     val meshIRIs = pubMedArticleWrapped.allMeshTermIDs map (

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -66,27 +66,22 @@ object OmnicorpTests extends TestSuite {
       val failedExamples1 = getClass.getResource("/pubmedXML/failedExamples1.xml").getPath
       val tmpFolder       = Files.createTempDirectory("omnicorp-testing").toFile
 
-      test("Make sure we get an error message on executing Omnicorp on this example file") {
+      test("Make sure we get a warning message on executing Omnicorp on this example file") {
         val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1"""))
 
-        // Make sure that the output file does not have triples indicating completion.
-        val outputFile = new File(tmpFolder, "failedExamples1.xml.ttl")
-        val outputBuffer = Source.fromFile(outputFile)
-        val output = outputBuffer.getLines().mkString("\n")
-        assert(output contains "")
-        outputBuffer.close()
-
         // Clean up temporary folder.
+        val outputFile = new File(tmpFolder, "failedExamples1.xml.ttl")
         outputFile.delete()
         tmpFolder.delete()
 
         // Test output and errors.
-        assert(status == 1)
+        assert(status == 0)
         assert(stdout contains "Total time:")
         assert(stdout contains "completed")
-        assert(stdout contains "Nonzero exit code: 1")
 
         assert(stderr contains "Begin processing")
+        assert(stderr contains "WARN org.renci.chemotext.PubMedTripleGenerator")
+        assert(stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>")
         assert(stderr contains "Done processing")
       }
     }

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -1,6 +1,5 @@
 package org.renci.chemotext
 
-import scala.io.Source
 import java.io.File
 import java.nio.file.Files
 
@@ -41,14 +40,8 @@ object OmnicorpTests extends TestSuite {
       test("Make sure we can execute Omnicorp on the example file") {
         val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
 
-        // Make sure that the output file has triples indicating completion.
-        val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
-        val outputBuffer = Source.fromFile(outputFile)
-        val output = outputBuffer.getLines().mkString("\n")
-        assert(output contains "")
-        outputBuffer.close()
-
         // Clean up temporary folder.
+        val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
         outputFile.delete()
         tmpFolder.delete()
 

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -38,7 +38,8 @@ object OmnicorpTests extends TestSuite {
       val tmpFolder        = Files.createTempDirectory("omnicorp-testing").toFile
 
       test("Make sure we can execute Omnicorp on the example file") {
-        val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
+        val (status, stdout, stderr) =
+          exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
 
         // Clean up temporary folder.
         val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
@@ -60,7 +61,8 @@ object OmnicorpTests extends TestSuite {
       val tmpFolder       = Files.createTempDirectory("omnicorp-testing").toFile
 
       test("Make sure we get a warning message on executing Omnicorp on this example file") {
-        val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1"""))
+        val (status, stdout, stderr) =
+          exec(Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1"""))
 
         // Clean up temporary folder.
         val outputFile = new File(tmpFolder, "failedExamples1.xml.ttl")
@@ -74,7 +76,9 @@ object OmnicorpTests extends TestSuite {
 
         assert(stderr contains "Begin processing")
         assert(stderr contains "WARN org.renci.chemotext.PubMedTripleGenerator")
-        assert(stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>")
+        assert(
+          stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>"
+        )
         assert(stderr contains "Done processing")
       }
     }

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -1,5 +1,6 @@
 package org.renci.chemotext
 
+import scala.io.Source
 import java.io.File
 import java.nio.file.Files
 
@@ -38,11 +39,17 @@ object OmnicorpTests extends TestSuite {
       val tmpFolder        = Files.createTempDirectory("omnicorp-testing").toFile
 
       test("Make sure we can execute Omnicorp on the example file") {
-        val cmdline                  = Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1""")
-        val (status, stdout, stderr) = exec(cmdline)
+        val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$examplesForTests" "$tmpFolder" 1"""))
+
+        // Make sure that the output file has triples indicating completion.
+        val outputFile = new File(tmpFolder, "examplesForTests.xml.ttl")
+        val outputBuffer = Source.fromFile(outputFile)
+        val output = outputBuffer.getLines().mkString("\n")
+        assert(output contains "")
+        outputBuffer.close()
 
         // Clean up temporary folder.
-        new File(tmpFolder, "examplesForTests.xml.ttl").delete()
+        outputFile.delete()
         tmpFolder.delete()
 
         // Test output and errors.
@@ -60,11 +67,17 @@ object OmnicorpTests extends TestSuite {
       val tmpFolder       = Files.createTempDirectory("omnicorp-testing").toFile
 
       test("Make sure we get an error message on executing Omnicorp on this example file") {
-        val cmdline                  = Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1""")
-        val (status, stdout, stderr) = exec(cmdline)
+        val (status, stdout, stderr) = exec(Seq("sbt", s"""run none "$failedExamples1" "$tmpFolder" 1"""))
+
+        // Make sure that the output file does not have triples indicating completion.
+        val outputFile = new File(tmpFolder, "failedExamples1.xml.ttl")
+        val outputBuffer = Source.fromFile(outputFile)
+        val output = outputBuffer.getLines().mkString("\n")
+        assert(output contains "")
+        outputBuffer.close()
 
         // Clean up temporary folder.
-        new File(tmpFolder, "failedExamples1.xml.ttl").delete()
+        outputFile.delete()
         tmpFolder.delete()
 
         // Test output and errors.


### PR DESCRIPTION
We previously threw an exception when a date could not be parsed. While this was fine when dealing with small input files, it doesn't work when a 2+ hour processing run is interrupted by an exception and has to be re-run. Instead, this PR replaces the exception with a warning onto STDERR. It also adds tests to check that these warnings are produced correctly.