### PR TITLE
Add SHACL shapes for Omnicorp data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ target
 /SciGraph
 /omnicorp-scigraph
 /.idea
+/.java-version
 ontologies-merged.ttl
 
 # Ignore input and output directories.
@@ -20,6 +21,9 @@ ontologies-merged.ttl
 # Ignore robot.
 /robot
 /robot.jar
+
+# Ignore coursier.
+/coursier
 
 # Ignore log files.
 /pubmed-terms.log

--- a/Makefile
+++ b/Makefile
@@ -44,5 +44,12 @@ output: $(OMNICORP) pubmed-annual-baseline omnicorp-scigraph
 	rm -rf $@ && mkdir -p $@ &&\
 	JAVA_OPTS="-Xmx$(MEMORY)" $(OMNICORP) omnicorp-scigraph pubmed-annual-baseline $@ $(PARALLEL)
 
-test: output
-	JAVA_OPTS="-Xmx$(MEMORY)" coursier launch com.ggvaidya:shacli_2.12:0.1-SNAPSHOT -- validate shacl/omnicorp-shapes.ttl output/*.ttl
+coursier:
+	# These are in the Linux installation instructions as per https://get-coursier.io/docs/cli-overview.html#linux
+	# Please create ./coursier as needed on your operating system.
+	curl -Lo coursier https://git.io/coursier-cli-linux &&
+	chmod +x coursier &&
+	./coursier --help
+
+test: coursier output
+	JAVA_OPTS="-Xmx$(MEMORY)" ./coursier launch com.ggvaidya:shacli_2.12:0.1-SNAPSHOT -- validate shacl/omnicorp-shapes.ttl output/*.ttl

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,6 @@ $(OMNICORP): SciGraph
 output: $(OMNICORP) pubmed-annual-baseline omnicorp-scigraph
 	rm -rf $@ && mkdir -p $@ &&\
 	JAVA_OPTS="-Xmx$(MEMORY)" $(OMNICORP) omnicorp-scigraph pubmed-annual-baseline $@ $(PARALLEL)
+
+test: output
+	JAVA_OPTS="-Xmx$(MEMORY)" coursier launch com.ggvaidya:shacli_2.12:0.1-SNAPSHOT -- validate shacl/omnicorp-shapes.ttl output/*.ttl

--- a/shacl/generated.ttl
+++ b/shacl/generated.ttl
@@ -1,0 +1,211 @@
+@prefix :      <http://example.org/> .
+@prefix shacl: <http://www.w3.org/ns/shacl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix fabio: <http://purl.org/spar/fabio/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix frbr:  <http://purl.org/vocab/frbr/core#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
+@prefix dc:    <http://purl.org/dc/terms/> .
+
+:JournalShape  a           shacl:NodeShape ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         dc:title
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         fabio:hasNLMJournalTitleAbbreviation
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "0"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:issn
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         rdf:type
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "0"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:eIssn
+                           ] ;
+        shacl:targetClass  fabio:Journal .
+
+:ArticleShape  a           shacl:NodeShape ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:pageRange
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:date ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         dc:modified
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "0"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:endingPage
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "0"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:doi
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:gYear ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         fabio:hasPublicationYear
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "0"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:startingPage
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "150"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         dc:references
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         dc:bibliographicCitation
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         dc:title
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         dc:creator
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         frbr:partOf
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         rdf:type
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:date , xsd:gYear , xsd:gYearMonth ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         dc:issued
+                           ] ;
+        shacl:targetClass  fabio:Article .
+
+:AgentShape  a             shacl:NodeShape ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         foaf:givenName
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         rdf:type
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         foaf:familyName
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         foaf:name
+                           ] ;
+        shacl:targetClass  foaf:Agent .
+
+:JournalIssueShape  a      shacl:NodeShape ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         frbr:partOf
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         rdf:type
+                           ] ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:issueIdentifier
+                           ] ;
+        shacl:targetClass  fabio:JournalIssue .
+
+:JournalVolumeShape  a     shacl:NodeShape ;
+        shacl:property     [ shacl:datatype     xsd:string ;
+                             shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:Literal ;
+                             shacl:path         prism:volume
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         rdf:type
+                           ] ;
+        shacl:property     [ shacl:description  "Enter description here" ;
+                             shacl:maxCount     "1"^^xsd:long ;
+                             shacl:minCount     "1"^^xsd:long ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:path         frbr:partOf
+                           ] ;
+        shacl:targetClass  fabio:JournalVolume .

--- a/shacl/omnicorp-shapes.ttl
+++ b/shacl/omnicorp-shapes.ttl
@@ -1,0 +1,204 @@
+@prefix :      <http://example.org/> .
+@prefix shacl: <http://www.w3.org/ns/shacl#> .
+@prefix dash:  <http://datashapes.org/dash#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix fabio: <http://purl.org/spar/fabio/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix frbr:  <http://purl.org/vocab/frbr/core#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
+@prefix dc:    <http://purl.org/dc/terms/> .
+
+# Articles are the primary unit of data in Omnicorp.
+:ArticleShape  a           shacl:NodeShape ;
+        shacl:targetClass  fabio:Article ;
+        shacl:property     [ shacl:path         dc:bibliographicCitation ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The bibliographic citation contains a full citation to this article." ;
+                             shacl:maxCount     1 ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         dc:modified ;
+                             shacl:datatype     xsd:date ;
+                             shacl:description  "The date on which this entry was last modified in PubMed." ;
+                             shacl:maxCount     1 ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         dc:title ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The article title" ;
+                             shacl:maxCount     1 ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         dc:creator ;
+                             shacl:description  "Enter description here" ;
+                             shacl:node         dash:ListShape ;
+                             shacl:property [
+                                shacl:path (
+                                  [ shacl:zeroOrMorePath rdf:rest ]
+                                  rdf:first
+                                ) ;
+                                shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                                shacl:node      :AgentShape
+                             ]
+                           ] ;
+        shacl:property     [ shacl:path         fabio:hasPublicationYear ;
+                             shacl:datatype     xsd:gYear ;
+                             shacl:description  "The year in which this article was published" ;
+                             shacl:maxCount     1 ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         dc:issued ;
+                             shacl:or (
+                                [shacl:datatype xsd:date]
+                                [shacl:datatype xsd:gYear]
+                                [shacl:datatype xsd:gYearMonth]
+                             ) ;
+                             shacl:description  "The date on which this PubMed entry was published, not necessarily related to the date of its creation or last modification" ;
+                             shacl:maxCount     1 ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         prism:doi ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The DOI of this publication" ;
+                             shacl:minCount     0 ;
+                             shacl:maxCount     1 ;
+                             shacl:nodeKind     shacl:Literal ;
+                           ] ;
+        shacl:property     [ shacl:path         prism:startingPage ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The starting page number of this article in its source journal." ;
+                             shacl:minCount     0 ;
+                             shacl:maxCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [
+                             shacl:path         prism:endingPage ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The ending page number of this article in its source journal" ;
+                             shacl:minCount     0 ;
+                             shacl:maxCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+       shacl:property      [ shacl:path         prism:pageRange ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The page range of this article in its source journal" ;
+                             shacl:minCount     1 ;
+                             shacl:maxCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         dc:references ;
+                             shacl:description  "The number of concepts referenced by this publication, based on terms in its abstract and (possibly) full-text" ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:IRI
+                           ] ;
+        shacl:property     [ shacl:path         frbr:partOf ;
+                             shacl:description  "The journal issue, volume or journal this article is a part of" ;
+                             shacl:maxCount     1 ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:BlankNodeOrIRI ;
+                             shacl:or (
+                               [ shacl:node     :JournalIssueShape ]
+                               [ shacl:node     :JournalVolumeShape ]
+                               [ shacl:node     :JournalShape ]
+                             )
+                           ]
+        .
+
+:AgentShape  a             shacl:NodeShape ;
+        shacl:targetClass  foaf:Agent ;
+        shacl:property     [
+                             shacl:path         foaf:name ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The name of this agent. May be further broken down into foaf:givenName and foaf:familyName. Note that single we identify agents by ORCID where available, we might end up with the same agent having multiple names (e.g. 'G Vaidya' vs 'Gaurav Vaidya')" ;
+                             shacl:minCount     1 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [ shacl:path         foaf:familyName ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The family name (or last name) of the agent" ;
+                             shacl:minCount     0 ;
+                             shacl:nodeKind     shacl:Literal
+                           ] ;
+        shacl:property     [
+                             shacl:path         foaf:givenName ;
+                             shacl:datatype     xsd:string ;
+                             shacl:description  "The given name (or first name) of the agent" ;
+                             shacl:minCount     0 ;
+                             shacl:nodeKind     shacl:Literal
+                           ]
+         .
+
+:JournalIssueShape  a    shacl:NodeShape ;
+      shacl:targetClass  fabio:JournalIssue ;
+      shacl:property     [ shacl:path         prism:issueIdentifier ;
+                           shacl:datatype     xsd:string ;
+                           shacl:description  "The issue number or identifier of this journal issue" ;
+                           shacl:maxCount     1 ;
+                           shacl:minCount     1 ;
+                           shacl:nodeKind     shacl:Literal
+                         ] ;
+      shacl:property     [ shacl:path         frbr:partOf ;
+                           shacl:description  "The journal volume this issue is a part of" ;
+                           shacl:maxCount     1 ;
+                           shacl:minCount     1 ;
+                           shacl:node         :JournalVolumeShape ;
+                           shacl:nodeKind     shacl:BlankNodeOrIRI
+                         ]
+      .
+
+:JournalVolumeShape  a   shacl:NodeShape ;
+      shacl:targetClass  fabio:JournalVolume ;
+      shacl:property     [ shacl:path         prism:volume ;
+                           shacl:datatype     xsd:string ;
+                           shacl:description  "The volume number or ID of the journal" ;
+                           shacl:maxCount     1 ;
+                           shacl:minCount     1 ;
+                           shacl:nodeKind     shacl:Literal
+                         ] ;
+      shacl:property     [ shacl:path         frbr:partOf ;
+                           shacl:description  "The journal this volume is a part of" ;
+                           shacl:maxCount     1 ;
+                           shacl:minCount     1 ;
+                           shacl:node         :JournalShape ;
+                           shacl:nodeKind     shacl:BlankNodeOrIRI
+                         ]
+      .
+
+:JournalShape  a         shacl:NodeShape ;
+      shacl:targetClass  fabio:Journal ;
+      shacl:property     [ shacl:path         dc:title ;
+                           shacl:datatype     xsd:string ;
+                           shacl:description  "The title of this journal" ;
+                           shacl:maxCount     1 ;
+                           shacl:minCount     1 ;
+                           shacl:nodeKind     shacl:Literal
+                         ] ;
+      shacl:property     [ shacl:path         fabio:hasNLMJournalTitleAbbreviation ;
+                           shacl:datatype     xsd:string ;
+                           shacl:description  "The NLM abbreviation for this journal title" ;
+                           shacl:minCount     0 ;
+                           shacl:maxCount     1 ;
+                           shacl:nodeKind     shacl:Literal
+                         ] ;
+      shacl:property     [ shacl:path         prism:issn ;
+                           shacl:datatype     xsd:string ;
+                           shacl:description  "The ISSN of this journal" ;
+                           shacl:minCount     0 ;
+                           shacl:maxCount     1 ;
+                           shacl:nodeKind     shacl:Literal
+                         ] ;
+      shacl:property     [ shacl:path         prism:eIssn ;
+                           shacl:datatype     xsd:string ;
+                           shacl:description  "The eISSN of this journal" ;
+                           shacl:minCount     0 ;
+                           shacl:maxCount     1 ;
+                           shacl:nodeKind     shacl:Literal
+                         ]
+      .

--- a/src/main/scala/org/renci/chemotext/AuthorWrapper.scala
+++ b/src/main/scala/org/renci/chemotext/AuthorWrapper.scala
@@ -17,7 +17,8 @@ class AuthorWrapper(node: Node) {
   // Support for identifiers.
   val identifier: immutable.Seq[(String, String)] =
     (node \ "Identifier").map(id => (id.attribute("Source").map(_.text).mkString(", ") -> id.text))
-  val orcIds: Seq[String] = identifier.filter(_._1 == "ORCID")
+  val orcIds: Seq[String] = identifier
+    .filter(_._1 == "ORCID")
     .map(_._2)
     .map(_.replaceAll("[\\s+\\-]", ""))
     .map(_.replaceAll("^https?:\\/\\/(?:www.)?orcid.org\\/", ""))

--- a/src/main/scala/org/renci/chemotext/AuthorWrapper.scala
+++ b/src/main/scala/org/renci/chemotext/AuthorWrapper.scala
@@ -17,7 +17,12 @@ class AuthorWrapper(node: Node) {
   // Support for identifiers.
   val identifier: immutable.Seq[(String, String)] =
     (node \ "Identifier").map(id => (id.attribute("Source").map(_.text).mkString(", ") -> id.text))
-  val orcIds: Seq[String] = identifier.filter(_._1 == "ORCID").map(_._2)
+  val orcIds: Seq[String] = identifier.filter(_._1 == "ORCID")
+    .map(_._2)
+    .map(_.replaceAll("[\\s+\\-]", ""))
+    .map(_.replaceAll("^https?:\\/\\/(?:www.)?orcid.org\\/", ""))
+    .map(_.replaceAll("(.{4})(?!$)", "$1-"))
+    .map("https://orcid.org/" + _.trim)
 
   // FOAF uses foaf:givenName and foaf:familyName.
   val givenName: String = foreName

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -236,16 +236,12 @@ object PubMedTripleGenerator extends LazyLogging {
           var orcid = author.orcIds.headOption
             // We shouldn't need the getOrElse part of this, but just in case,
             // that's the ORCID testing URI: https://orcid.org/0000-0002-1825-0097
-            .getOrElse("0000-0002-1825-0097")
+            .getOrElse("https://orcid.org/0000-0002-1825-0097")
             // We also have a buggy ORCID in the system that includes an internal
             // space. This breaks our output, since for some reason this isn't
             // escaped properly when writing it out in Turtle.
             .replace("\\s", "")
 
-          if (
-            !orcid.startsWith("http://") &&
-            !orcid.startsWith("https://")
-          ) orcid = "https://orcid.org/" + orcid
           authorModel.createResource(orcid, FOAF.Agent)
         }
 

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -234,8 +234,8 @@ object PubMedTripleGenerator extends LazyLogging {
         if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent)
         else {
           val orcid = author.orcIds.headOption
-            // We shouldn't need the getOrElse part of this, but just in case,
-            // that's the ORCID testing URI: https://orcid.org/0000-0002-1825-0097
+          // We shouldn't need the getOrElse part of this, but just in case,
+          // that's the ORCID testing URI: https://orcid.org/0000-0002-1825-0097
             .getOrElse("https://orcid.org/0000-0002-1825-0097")
             // We also have a buggy ORCID in the system that includes an internal
             // space. This breaks our output, since for some reason this isn't
@@ -404,7 +404,8 @@ object Main extends App with LazyLogging {
         StreamRDFOps.sendTriplesToStream(triples.iterator.asJava, rdfStream)
         if (tripleCount % 100 == 0)
           logger.info(
-            s"Approximately %,d triples added from %,d articles in %s.".format(tripleCount, articleCount, file)
+            s"Approximately %,d triples added from %,d articles in %s."
+              .format(tripleCount, articleCount, file)
           )
       }
 

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -233,9 +233,15 @@ object PubMedTripleGenerator extends LazyLogging {
       val authorResource =
         if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent)
         else {
-          var orcid = author.orcIds.headOption.getOrElse("0000-0002-1825-0097")
+          var orcid = author.orcIds.headOption
             // We shouldn't need the getOrElse part of this, but just in case,
             // that's the ORCID testing URI: https://orcid.org/0000-0002-1825-0097
+            .getOrElse("0000-0002-1825-0097")
+            // We also have a buggy ORCID in the system that includes an internal
+            // space. This breaks our output, since for some reason this isn't
+            // escaped properly when writing it out in Turtle.
+            .replace("\\s", "")
+
           if (
             !orcid.startsWith("http://") &&
             !orcid.startsWith("https://")

--- a/src/main/scala/org/renci/chemotext/Main.scala
+++ b/src/main/scala/org/renci/chemotext/Main.scala
@@ -21,7 +21,7 @@ import io.scigraph.vocabulary.{Vocabulary, VocabularyNeo4jImpl}
 import org.apache.jena.datatypes.xsd.XSDDatatype
 import org.apache.jena.graph
 import org.apache.jena.rdf.model.{ModelFactory, Property, Resource, ResourceFactory, Statement}
-import org.apache.jena.riot.{Lang, RDFFormat}
+import org.apache.jena.riot.RDFFormat
 import org.apache.jena.riot.system.{StreamRDFOps, StreamRDFWriter}
 import org.apache.jena.vocabulary.{DCTerms, RDF}
 import org.apache.jena.sparql.vocabulary.FOAF
@@ -233,7 +233,7 @@ object PubMedTripleGenerator extends LazyLogging {
       val authorResource =
         if (author.orcIds.isEmpty) authorModel.createResource(FOAF.Agent)
         else {
-          var orcid = author.orcIds.headOption
+          val orcid = author.orcIds.headOption
             // We shouldn't need the getOrElse part of this, but just in case,
             // that's the ORCID testing URI: https://orcid.org/0000-0002-1825-0097
             .getOrElse("https://orcid.org/0000-0002-1825-0097")

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -182,7 +182,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       assert(
         summarizedTriples == Map(
-          "https://orcid.org/0000000305870454" -> Map(
+          "https://orcid.org/0000-0003-0587-0454" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI"                                     -> 1),
             "http://xmlns.com/foaf/0.1/name"                  -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://xmlns.com/foaf/0.1/familyName" -> Map(
@@ -257,7 +257,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         @prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
         @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
-        <https://orcid.org/0000000305870454> a foaf:Agent ;
+        <https://orcid.org/0000-0003-0587-0454> a foaf:Agent ;
           foaf:familyName  "Vaidya Jr" ;
           foaf:givenName   "Gaurav" ;
           foaf:name        "Gaurav Vaidya Jr" .
@@ -278,7 +278,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
                                                foaf:givenName   "Kwong" ;
                                                foaf:name        "Kwong Shiyang"
                                              ]
-                                             <https://orcid.org/0000000305870454>
+                                             <https://orcid.org/0000-0003-0587-0454>
                                              [ a foaf:Agent ;
                                                foaf:familyName  "Ng" ;
                                                foaf:givenName   "Peter K L" ;

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperIntegrationTests.scala
@@ -182,7 +182,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
 
       assert(
         summarizedTriples == Map(
-          "http://orcid.org/0000000305870454#person" -> Map(
+          "https://orcid.org/0000000305870454" -> Map(
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" -> Map("URI"                                     -> 1),
             "http://xmlns.com/foaf/0.1/name"                  -> Map("http://www.w3.org/2001/XMLSchema#string" -> 1),
             "http://xmlns.com/foaf/0.1/familyName" -> Map(
@@ -257,7 +257,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
         @prefix prism: <http://prismstandard.org/namespaces/basic/3.0/> .
         @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 
-        <http://orcid.org/0000000305870454#person> a foaf:Agent ;
+        <https://orcid.org/0000000305870454> a foaf:Agent ;
           foaf:familyName  "Vaidya Jr" ;
           foaf:givenName   "Gaurav" ;
           foaf:name        "Gaurav Vaidya Jr" .
@@ -278,7 +278,7 @@ object PubMedArticleWrapperIntegrationTests extends TestSuite {
                                                foaf:givenName   "Kwong" ;
                                                foaf:name        "Kwong Shiyang"
                                              ]
-                                             <http://orcid.org/0000000305870454#person>
+                                             <https://orcid.org/0000000305870454>
                                              [ a foaf:Agent ;
                                                foaf:familyName  "Ng" ;
                                                foaf:givenName   "Peter K L" ;

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -17,44 +17,97 @@ import scala.util.Success
 )
 object PubMedArticleWrapperUnitTests extends TestSuite {
   val tests = Tests {
-    test("#parseDate") {
-      test("Test processing of valid dates") {
-        val datesTested = Seq(
-          (Year.of(2006), <PubDate><Year>2006</Year></PubDate>),
-          (YearMonth.of(2006, 10), <PubDate><Year>2006</Year><Month>Oct</Month></PubDate>),
-          (
-            LocalDate.of(2006, 10, 21),
-            <PubDate><Year>2006</Year><Day>21</Day><Month>Oct</Month></PubDate>
-          ),
-          (Year.of(1998), <PubDate><MedlineDate>1998 Dec-1999 Jan</MedlineDate></PubDate>),
-          (
-            LocalDate.of(2006, 10, 21),
-            <PubDate><Year>2006</Year><Day>21</Day><Month>10</Month></PubDate>
-          ),
-          (Year.of(2016), <PubDate><MedlineDate>Summer 2016</MedlineDate></PubDate>)
-        )
-
-        datesTested.foreach({
-          case (expected, xmlNode) =>
-            assert(PubMedArticleWrapper.parseDate(xmlNode) == Success(expected))
-        })
+    test("AuthorWrapper") {
+      test("#orcIds") {
+        test("ORCID as a plain number") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">0000000305870454</Identifier>
+          </Author>).orcIds
+          println(orcids)
+          assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
+        }
+        test("ORCID as a hyphenated number") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">0000-0003-0587-0454</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
+        }
+        test("ORCID with embedded spaces") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">0000 0003 0587 0454</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
+        }
+        test("ORCID with spaces instead of hyphens") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">0000-0003 0587-0454</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
+        }
+        test("ORCID with HTTP URL") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">http://orcid.org/0000-0003-0587-0454</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
+        }
       }
-      test("Test processing of invalid dates") {
-        assert(
-          (intercept[IllegalArgumentException] {
-            PubMedArticleWrapper
-              .parseDate(<PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>)
-              .get
-          }).getMessage == "Could not parse XML node as date: <PubDate><MedlineDate>199 Dec-199 Jan</MedlineDate></PubDate>"
-        )
-        assert((intercept[IllegalArgumentException] {
-          PubMedArticleWrapper.parseDate(<PubDate></PubDate>).get
-        }).getMessage == "Could not parse XML node as date: <PubDate></PubDate>")
-        assert(
-          (intercept[RuntimeException] {
-            PubMedArticleWrapper.parseDate(<PubDate><Year>2019</Year><Day>12</Day></PubDate>).get
-          }).getMessage == "Could not extract month from node: <PubDate><Year>2019</Year><Day>12</Day></PubDate>"
-        )
+    }
+    test("PubMedArticleWrapper") {
+      test("#parseDate") {
+        test("Test processing of valid dates") {
+          val datesTested = Seq(
+            (Year.of(2006), <PubDate>
+              <Year>2006</Year>
+            </PubDate>),
+            (YearMonth.of(2006, 10), <PubDate>
+              <Year>2006</Year> <Month>Oct</Month>
+            </PubDate>),
+            (
+              LocalDate.of(2006, 10, 21),
+              <PubDate>
+                <Year>2006</Year> <Day>21</Day> <Month>Oct</Month>
+              </PubDate>
+            ),
+            (Year.of(1998), <PubDate>
+              <MedlineDate>1998 Dec-1999 Jan</MedlineDate>
+            </PubDate>),
+            (
+              LocalDate.of(2006, 10, 21),
+              <PubDate>
+                <Year>2006</Year> <Day>21</Day> <Month>10</Month>
+              </PubDate>
+            ),
+            (Year.of(2016), <PubDate>
+              <MedlineDate>Summer 2016</MedlineDate>
+            </PubDate>)
+          )
+
+          datesTested.foreach({
+            case (expected, xmlNode) =>
+              assert(PubMedArticleWrapper.parseDate(xmlNode) == Success(expected))
+          })
+        }
+        test("Test processing of invalid dates") {
+          assert(
+            (intercept[IllegalArgumentException] {
+              PubMedArticleWrapper
+                .parseDate(<PubDate>
+                  <MedlineDate>199 Dec-199 Jan</MedlineDate>
+                </PubDate>)
+                .get
+            }).getMessage matches "Could not parse XML node as date: <PubDate>\\s*<MedlineDate>199 Dec-199 Jan</MedlineDate>\\s*</PubDate>"
+          )
+          assert((intercept[IllegalArgumentException] {
+            PubMedArticleWrapper.parseDate(<PubDate></PubDate>).get
+          }).getMessage == "Could not parse XML node as date: <PubDate></PubDate>")
+          assert(
+            (intercept[RuntimeException] {
+              PubMedArticleWrapper.parseDate(<PubDate>
+                <Year>2019</Year> <Day>12</Day>
+              </PubDate>).get
+            }).getMessage matches "Could not extract month from node: <PubDate>\\s*<Year>2019</Year> <Day>12</Day>\\s*</PubDate>"
+          )
+        }
       }
     }
   }

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -55,32 +55,19 @@ object PubMedArticleWrapperUnitTests extends TestSuite {
     test("PubMedArticleWrapper") {
       test("#parseDate") {
         test("Test processing of valid dates") {
-          val datesTested = Seq(
-            (Year.of(2006), <PubDate>
+          val datesTested = Seq((Year.of(2006), <PubDate>
               <Year>2006</Year>
-            </PubDate>),
-            (YearMonth.of(2006, 10), <PubDate>
+            </PubDate>), (YearMonth.of(2006, 10), <PubDate>
               <Year>2006</Year> <Month>Oct</Month>
-            </PubDate>),
-            (
-              LocalDate.of(2006, 10, 21),
-              <PubDate>
+            </PubDate>), (LocalDate.of(2006, 10, 21), <PubDate>
                 <Year>2006</Year> <Day>21</Day> <Month>Oct</Month>
-              </PubDate>
-            ),
-            (Year.of(1998), <PubDate>
+              </PubDate>), (Year.of(1998), <PubDate>
               <MedlineDate>1998 Dec-1999 Jan</MedlineDate>
-            </PubDate>),
-            (
-              LocalDate.of(2006, 10, 21),
-              <PubDate>
+            </PubDate>), (LocalDate.of(2006, 10, 21), <PubDate>
                 <Year>2006</Year> <Day>21</Day> <Month>10</Month>
-              </PubDate>
-            ),
-            (Year.of(2016), <PubDate>
+              </PubDate>), (Year.of(2016), <PubDate>
               <MedlineDate>Summer 2016</MedlineDate>
-            </PubDate>)
-          )
+            </PubDate>))
 
           datesTested.foreach({
             case (expected, xmlNode) =>


### PR DESCRIPTION
This PR adds SHACL shapes that can be used to validate Omnicorp data. It also fixes some formatting issues with ORCIDs I discovered as a result of SHACL validation.