### PR TITLE
Extract CORD data into a format that Omnicorp can ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ontologies-merged.ttl
 /output
 /results
 /robocord-data
+/robocord-datas
 /robocord-output
 
 # Ignore robot.

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ target
 ontologies-merged.ttl
 
 # Ignore input and output directories.
-/pubmed-annual-baseline
+pubmed-annual-baseline
 /output
 /results
 /robocord-data

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ ontologies-merged.ttl
 /pubmed-annual-baseline
 /output
 /results
+/robocord-data
+/robocord-output
 
 # Ignore robot.
 /robot

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MEMORY = 16G
 PARALLEL = 4
 
 # The date of CORD-19 data to download.
-ROBOCORD_DATE="2020-03-13"
+ROBOCORD_DATE="2020-03-20"
 
 .PHONY: all
 all: output
@@ -59,19 +59,21 @@ test: coursier output
 
 
 # RoboCORD
-.PHONY: robocord-download
+.PHONY: robocord-download robocord-output robocord-test
 robocord-download:
 	# rm -rf robocord-data
-	# wget "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/comm_use_subset.tar.gz" -P robocord-data
+	wget "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/comm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/noncomm_use_subset.tar.gz" -P robocord-data
-	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/pmc_custom_license.tar.gz" -P robocord-data
+	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/custom_license.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/biorxiv_medrxiv.tar.gz" -P robocord-data
-	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/all_sources_metadata_${ROBOCORD_DATE}.csv" -P robocord-data
-	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/all_sources_metadata_${ROBOCORD_DATE}.readme" -P robocord-data
+	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/metadata.csv" -P robocord-data
 
 robocord-data: robocord-download
 	cd robocord-data; for f in *.tar.gz; do echo Uncompressing "$$f"; tar zxvf $$f; done; cd -
 	touch robocord-data
 
 robocord-output: robocord-data SciGraph
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/all_sources_metadata_${ROBOCORD_DATE}.csv robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv robocord-data"
+
+robocord-test: SciGraph
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --currentChunk 0 --totalChunks 10000 robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ test: coursier output
 
 
 # RoboCORD
+.PHONY: robocord-download
 robocord-download:
+	# rm -rf robocord-data
 	# wget "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/comm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/noncomm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/pmc_custom_license.tar.gz" -P robocord-data
@@ -69,6 +71,7 @@ robocord-download:
 
 robocord-data: robocord-download
 	cd robocord-data; for f in *.tar.gz; do echo Uncompressing "$$f"; tar zxvf $$f; done; cd -
+	touch robocord-data
 
 robocord-output: robocord-data SciGraph
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/all_sources_metadata_${ROBOCORD_DATE}.csv robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,20 @@ coursier:
 test: coursier output
 	JAVA_OPTS="-Xmx$(MEMORY)" ./coursier launch com.ggvaidya:shacli_2.12:0.1-SNAPSHOT -- validate shacl/omnicorp-shapes.ttl output/*.ttl
 
-
 # RoboCORD
 .PHONY: robocord-download robocord-output robocord-test
 robocord-download:
-	# rm -rf robocord-datas/${ROBOCORD_DATE}
-	-rm robocord-data
-	-mkdir robocord-datas/${ROBOCORD_DATE}
-	-ln -s robocord-datas/${ROBOCORD_DATE} robocord-data
+	# robocord-data is intended to be a symlink to robocord-datas/$ROBOCORD_DATE, so that it is updated automatically. 
+	# If robocord-data doesn't exist or is a symlink, we update it
+	# automatically. Otherwise (i.e. if it's an existing directory),
+	# we only update the files already in it.
+	@if [ ! -e robocord-data ] || [ -L robocord-data ]; then \
+		rm robocord-data; \
+		mkdir -p robocord-datas/${ROBOCORD_DATE}; \
+		ln -s robocord-datas/${ROBOCORD_DATE} robocord-data; \
+	fi
+	
+	# Download CORD-19 into robocord-data.
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/comm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/noncomm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/custom_license.tar.gz" -P robocord-data

--- a/Makefile
+++ b/Makefile
@@ -76,4 +76,7 @@ robocord-output: robocord-data SciGraph
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv robocord-data"
 
 robocord-test: SciGraph
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --currentChunk 0 --totalChunks 10000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 0 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 1 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 2 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 3 --total-chunks 1000 robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MEMORY = 16G
 PARALLEL = 4
 
 # The date of CORD-19 data to download.
-ROBOCORD_DATE="2020-03-20"
+ROBOCORD_DATE="2020-03-27"
 
 .PHONY: all
 all: output
@@ -64,8 +64,11 @@ test: coursier output
 # RoboCORD
 .PHONY: robocord-download robocord-output robocord-test
 robocord-download:
-	# rm -rf robocord-data
-	wget "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/comm_use_subset.tar.gz" -P robocord-data
+	# rm -rf robocord-datas/${ROBOCORD_DATE}
+	-rm robocord-data
+	-mkdir robocord-datas/${ROBOCORD_DATE}
+	-ln -s robocord-datas/${ROBOCORD_DATE} robocord-data
+	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/comm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/noncomm_use_subset.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/custom_license.tar.gz" -P robocord-data
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/${ROBOCORD_DATE}/biorxiv_medrxiv.tar.gz" -P robocord-data

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,11 @@ robot.jar:
 robot: robot.jar
 	curl -L -O https://raw.githubusercontent.com/ontodev/robot/master/bin/robot && chmod +x robot
 
-ontologies-merged.ttl: robot ontologies.ofn
-	ROBOT_JAVA_ARGS=-Xmx$(MEMORY) ./robot merge -i ontologies.ofn -o ontologies-merged.ttl
+ontologies-merged-original.ttl: robot ontologies.ofn
+	ROBOT_JAVA_ARGS=-Xmx$(MEMORY) ./robot merge -i ontologies.ofn -o ontologies-merged-original.ttl
+
+ontologies-merged.ttl: ontologies-merged-original.ttl manually_added.ttl
+	cat ontologies-merged-original.ttl manually_added.ttl > ontologies-merged.ttl
 
 omnicorp-scigraph: ontologies-merged.ttl SciGraph
 	rm -rf $@ && cd SciGraph/SciGraph-core &&\

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,8 @@ robot.jar:
 robot: robot.jar
 	curl -L -O https://raw.githubusercontent.com/ontodev/robot/master/bin/robot && chmod +x robot
 
-ontologies-merged-original.ttl: robot ontologies.ofn
-	ROBOT_JAVA_ARGS=-Xmx$(MEMORY) ./robot merge -i ontologies.ofn -o ontologies-merged-original.ttl
-
-ontologies-merged.ttl: ontologies-merged-original.ttl manually_added.ttl
-	cat ontologies-merged-original.ttl manually_added.ttl > ontologies-merged.ttl
+ontologies-merged.ttl: robot ontologies.ofn
+	ROBOT_JAVA_ARGS=-Xmx$(MEMORY) ./robot merge -i ontologies.ofn -i manually_added.ttl -o ontologies-merged.ttl
 
 omnicorp-scigraph: ontologies-merged.ttl SciGraph
 	rm -rf $@ && cd SciGraph/SciGraph-core &&\

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,6 @@ libraryDependencies ++= {
     "io.circe"                    %% "circe-parser"           % "0.13.0",
 
     // CSV parsing.
-    "zamblauskas"                 %% "scala-csv-parser"       % "0.11.4"
+    "com.github.tototoshi"        %% "scala-csv"              % "1.3.6"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,14 @@ libraryDependencies ++= {
     "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
     "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
-    "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test"
+    "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test",
+
+    // Command line argument parsing.
+    "org.rogach"                  %% "scallop"                % "3.3.2",
+
+    // JSON parsing.
+    "io.circe"                    %% "circe-core"             % "0.13.0",
+    "io.circe"                    %% "circe-generic"          % "0.13.0",
+    "io.circe"                    %% "circe-parser"           % "0.13.0"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 // Dependency information.
 
 resolvers += Resolver.mavenLocal
-resolvers += Resolver.bintrayRepo("zamblauskas", "maven")
 
 libraryDependencies ++= {
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 // Dependency information.
 
 resolvers += Resolver.mavenLocal
+resolvers += Resolver.bintrayRepo("zamblauskas", "maven")
 
 libraryDependencies ++= {
   Seq(
@@ -55,6 +56,9 @@ libraryDependencies ++= {
     // JSON parsing.
     "io.circe"                    %% "circe-core"             % "0.13.0",
     "io.circe"                    %% "circe-generic"          % "0.13.0",
-    "io.circe"                    %% "circe-parser"           % "0.13.0"
+    "io.circe"                    %% "circe-parser"           % "0.13.0",
+
+    // CSV parsing.
+    "zamblauskas"                 %% "scala-csv-parser"       % "0.11.4"
   )
 }

--- a/manually_added.ttl
+++ b/manually_added.ttl
@@ -1,0 +1,107 @@
+####
+# Manually added to the ontology.
+####
+
+#@prefix : <https://github.com/NCATS-Gamma/omnicorp/ontologies.ofn#> .
+#@prefix owl: <http://www.w3.org/2002/07/owl#> .
+#@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+#@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+#@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+#@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+#@base <https://github.com/NCATS-Gamma/omnicorp/ontologies.ofn> .
+
+###  http://purl.obolibrary.org/obo/NCBITaxon_2697049
+<http://purl.obolibrary.org/obo/NCBITaxon_2697049> rdf:type owl:Class ;
+                                                  rdfs:subClassOf <http://purl.obolibrary.org/obo/NCBITaxon_694009> ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> "COVID19"^^xsd:string ,
+                                                                                                                 "SARS-2"^^xsd:string ,
+                                                                                                                 "SARS-CoV-2"^^xsd:string ,
+														 "HCoV-19"^^xsd:string ,
+														 "SARS2"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> "ncbi_taxonomy"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>   "Human coronavirus 2019"^^xsd:string ,
+                                                                                                                   "2019-nCoV"^^xsd:string ,
+                                                                                                                   "COVID-19"^^xsd:string ,
+                                                                                                                   "COVID-19 virus"^^xsd:string ,
+                                                                                                                   "Wuhan coronavirus"^^xsd:string ,
+                                                                                                                   "Wuhan seafood market pneumonia virus"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "NCBITaxon:2697049"^^xsd:string ;
+                                                  rdfs:label "Severe acute respiratory syndrome coronavirus 2"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> ;
+   owl:annotatedTarget "COVID19"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#synonym> # Should be heterotypic_synonym, but I'm not sure if that's a term.
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> ;
+   owl:annotatedTarget "SARS-2"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#synonym> # Should be heterotypic_synonym, but I'm not sure if that's a term.
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> ;
+   owl:annotatedTarget "SARS-CoV-2"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#genbank_acronym>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> ;
+   owl:annotatedTarget "HCoV-19"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#acronym>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> ;
+   owl:annotatedTarget "SARS2"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#acronym>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> ;
+   owl:annotatedTarget "Human coronavirus 2019"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#equivalent_name>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> ;
+   owl:annotatedTarget "2019-nCoV"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#equivalent_name>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> ;
+   owl:annotatedTarget "COVID-19"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#equivalent_name>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> ;
+   owl:annotatedTarget "COVID-19 virus"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#equivalent_name>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> ;
+   owl:annotatedTarget "Wuhan coronavirus"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#equivalent_name>
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://purl.obolibrary.org/obo/NCBITaxon_2697049> ;
+   owl:annotatedProperty <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> ;
+   owl:annotatedTarget "Wuhan seafood market pneumonia virus"^^xsd:string ;
+   <http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/ncbitaxon#equivalent_name>
+ ] .
+

--- a/robocord.job
+++ b/robocord.job
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+#SBATCH --job-name=RoboCORD
+#SBATCH --output=robocord-output/log-output-%a.txt
+#SBATCH --error=robocord-output/log-error-%a.txt
+#SBATCH --cpus-per-task 16
+#SBATCH --mem=50000
+#SBATCH --time=12:00:00
+#SBATCH --mail-user=gaurav@renci.org
+
+set -e # Exit immediately if a pipeline fails.
+
+export JAVA_OPTS="-Xmx50G"
+export MY_SCIGRAPH=omnicorp-scigraph-$SLURM_ARRAY_TASK_ID
+
+echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
+cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
+
+echo "Starting RoboCORD"
+sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk $SLURM_ARRAY_TASK_ID --total-chunks $SLURM_ARRAY_TASK_MAX --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+
+rm -rf "scigraphs/$MY_SCIGRAPH"
+echo "Deleted duplicated omnicorp-scigraph"

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -1,11 +1,17 @@
 package org.renci.robocord
 
-import java.io.File
+import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
+import java.time.Duration
 
 import com.typesafe.scalalogging.{LazyLogging, Logger}
-import org.renci.robocord.json.CORDJsonReader
+import org.renci.robocord.annotator.Annotator
+import org.renci.robocord.json.{CORDArticleWrapper, CORDJsonReader}
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
+import zamblauskas.csv.parser.Parser
+import zamblauskas.csv.parser._
+
+import scala.io.Source
 
 object RoboCORD extends App with LazyLogging {
   /**
@@ -24,16 +30,89 @@ object RoboCORD extends App with LazyLogging {
     version("RoboCORD: part of Omnicorp v" + version)
 
     val data: ScallopOption[List[File]] = trailArg[List[File]](descr = "Data file(s) or directories to convert (in JSON-LD)")
+    val metadata: ScallopOption[File] = opt[File](
+      descr = "The CSV file containing metadata",
+      default = Some(new File("robocord-data/all_sources_metadata_latest.csv"))
+    )
+    val output: ScallopOption[File] = opt[File](
+      descr = "Directory where report should be written",
+      default = Some(new File("robocord-results"))
+    )
+    val neo4jLocation: ScallopOption[File] = opt[File](
+      descr = "Location of the Neo4J database that SciGraph should use.",
+      default = Some(new File("omnicorp-scigraph"))
+    )
 
     verify()
   }
 
+  val timeStarted = System.nanoTime
+
   // Parse command line arguments.
   val conf = new Conf(args, logger)
 
-  // Which files do we need to process?
-  val dataFiles = conf.data()
+  // Load the metadata CSV file.
+  case class MetadataEntry (
+    sha: String,
+    source_x: String,
+    title: String,
+    doi: String,
+    pmcid: String,
+    pubmed_id: String,
+    license: String,
+    `abstract`: String,
+    publish_time: String,
+    authors: String,
+    journal: String,
+    `Microsoft Academic Paper ID`: String,
+    `WHO #Covidence`: String,
+    has_full_text: String
+  )
 
-  // Process!
-  dataFiles.foreach(CORDJsonReader.processFile(_, logger))
+  // Set up Annotator.
+  val annotator: Annotator = new Annotator(conf.neo4jLocation())
+
+  // Load the metadata file.
+  val metadataSource = Source.fromFile(conf.metadata())
+  val csvText = metadataSource.mkString
+  val metadata: Seq[MetadataEntry] = Parser.parse[MetadataEntry](csvText) match {
+    case Left(Parser.Failure(lineNum, line, message)) => throw new RuntimeException(s"Could not parse CSV metadata file ${conf.metadata()} on line $lineNum: $message\n\tLine: $line")
+    case Right(entries: Seq[MetadataEntry]) => entries
+  }
+  metadataSource.close()
+  val metadataMap = metadata.groupBy(_.sha)
+  logger.info(s"${metadata.size} metadata entries loaded from ${conf.metadata()}.")
+
+  // Which files do we need to process?
+  val wrappedData: Stream[CORDArticleWrapper] = conf.data().flatMap(CORDJsonReader.wrapFileOrDir(_, logger)).toStream
+
+  logger.info(s"${wrappedData.size} articles loaded from ${conf.data()}.")
+
+  // Summarize all files into the output directory.
+  // .par(conf.parallel())
+  val results = wrappedData.par.map(wrappedArticle => {
+    // Step 1. Find the metadata for this article.
+    val metadataEntry = metadataMap.get(wrappedArticle.sha1).head.head
+
+    // Step 2. Find the ID of this article.
+    val id = if (metadataEntry.pmcid.nonEmpty) s"PMCID:${metadataEntry.pmcid}"
+      else if(metadataEntry.doi.nonEmpty) s"DOI:${metadataEntry.doi}"
+      else s"sha1:${wrappedArticle.sha1}"
+
+    // Step 3. Find the annotations for this article.
+    val annotations = wrappedArticle.getSciGraphAnnotations(annotator)
+
+    // Step 4. Write them all out.
+    logger.info(s"Identified ${annotations.size} annotations for article $id")
+    annotations.map(annotation => s"$id\t${annotation.getToken.getId}\t${annotation.toString}")
+  })
+
+  // Write out all the results to the output file.
+  logger.info(s"Writing tab-delimited output to ${conf.output()}/results.txt.")
+  val pw = new PrintWriter(new FileWriter(new File(conf.output(), "results.txt")))
+  results.foreach(pw.println(_))
+  pw.close
+
+  val duration = Duration.ofNanos(System.nanoTime - timeStarted)
+  logger.info(s"Completed generating ${results.size} results for ${wrappedData.size} articles in ${duration.getSeconds} seconds ($duration)")
 }

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -94,7 +94,7 @@ object RoboCORD extends App with LazyLogging {
   // Divide allMetadata into chunks based on totalChunks.
   val metadata: Seq[Map[String, String]] = allMetadata.slice(startIndex, endIndex)
   val articlesTotal = metadata.size
-  logger.info(s"Selected $articlesTotal articles for processing (from $startIndex until $endIndex)")
+  logger.info(s"Selected $articlesTotal articles for processing (from $startIndex until $endIndex, chunk $currentChunk out of $totalChunks)")
 
   // We primarily pull the metadata from allMetadata, which includes abstracts. In some cases, however,
   // we also have full text for those files.

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -98,9 +98,11 @@ object RoboCORD extends App with LazyLogging {
       }
       case Some(List(metadata: Map[String, String])) => {
         // Step 2. Find the ID of this article.
+        val pmid = metadata.getOrElse("pubmed_id", "")
         val pmcid = metadata.getOrElse("pmcid", "")
         val doi = metadata.getOrElse("doi", "")
-        val id = if(pmcid != "") s"PMCID:$pmcid"
+        val id = if (pmid != "") s"PMID:$pmid"
+        else if(pmcid != "") s"PMCID:$pmcid"
         else if(doi != "") s"DOI:$doi"
         else s"sha1:${wrappedArticle.sha1}"
 

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -89,6 +89,8 @@ object RoboCORD extends App with LazyLogging {
 
   logger.info(s"${wrappedData.size} articles loaded from ${conf.data()}.")
 
+  logger.info(s"Starting SciGraph in parallel on ${Runtime.getRuntime.availableProcessors} processors.")
+
   // Summarize all files into the output directory.
   // .par(conf.parallel())
   val results: ParSeq[String] = wrappedData.par.flatMap(wrappedArticle => {

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -136,7 +136,7 @@ object RoboCORD extends App with LazyLogging {
 
     // Step 4. Write them all out.
     articlesCompleted += 1
-    val articlesPercentage = f"${articlesCompleted/articlesTotal*100}%.2f%%"
+    val articlesPercentage = f"${articlesCompleted.toFloat/articlesTotal*100}%.2f%%"
     logger.info(s"Identified ${annotations.size} annotations for article $id $withFullText (approx $articlesCompleted out of $articlesTotal, $articlesPercentage)")
     annotations.map(annotation => s"$id\t${annotation.getToken.getId}\t${annotation.toString}")
   })

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -11,7 +11,7 @@ import org.rogach.scallop.exceptions._
 import zamblauskas.csv.parser.Parser
 import zamblauskas.csv.parser._
 
-import scala.collection.parallel.immutable.ParSeq
+import scala.collection.parallel.ParSeq
 import scala.io.Source
 
 object RoboCORD extends App with LazyLogging {
@@ -85,7 +85,7 @@ object RoboCORD extends App with LazyLogging {
   logger.info(s"${metadata.size} metadata entries loaded from ${conf.metadata()}.")
 
   // Which files do we need to process?
-  val wrappedData: Stream[CORDArticleWrapper] = conf.data().flatMap(CORDJsonReader.wrapFileOrDir(_, logger)).toStream
+  val wrappedData: Seq[CORDArticleWrapper] = conf.data().flatMap(CORDJsonReader.wrapFileOrDir(_, logger))
 
   logger.info(s"${wrappedData.size} articles loaded from ${conf.data()}.")
 

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -102,7 +102,7 @@ object RoboCORD extends App with LazyLogging {
 
   // We primarily pull the metadata from allMetadata, which includes abstracts. In some cases, however,
   // we also have full text for those files.
-  val shasToLoad = metadata.map(_.get("sha")).flatten.map(_.toLowerCase).toSet
+  val shasToLoad = metadata.map(_.get("sha")).flatten.flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
   val fullTextData: Seq[CORDArticleWrapper] = conf.data().flatMap(CORDJsonReader.wrapFileOrDir(_, logger, shasToLoad))
   val fullTextBySHA: Map[String, Seq[CORDArticleWrapper]] = fullTextData.groupBy(_.sha1)
   logger.info(s"Loaded ${fullTextData.size} full text documents corresponding to ${fullTextBySHA.keySet.size} SHA hashes.")

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -1,0 +1,39 @@
+package org.renci.robocord
+
+import java.io.File
+
+import com.typesafe.scalalogging.{LazyLogging, Logger}
+import org.renci.robocord.json.CORDJsonReader
+import org.rogach.scallop._
+import org.rogach.scallop.exceptions._
+
+object RoboCORD extends App with LazyLogging {
+  /**
+   * Command line configuration for RoboCORD.
+   */
+  class Conf(arguments: Seq[String], logger: Logger) extends ScallopConf(arguments) {
+    override def onError(e: Throwable): Unit = e match {
+      case ScallopException(message) =>
+        printHelp
+        logger.error(message)
+        System.exit(1)
+      case ex => super.onError(ex)
+    }
+
+    val version: String = getClass.getPackage.getImplementationVersion
+    version("RoboCORD: part of Omnicorp v" + version)
+
+    val data: ScallopOption[List[File]] = trailArg[List[File]](descr = "Data file(s) or directories to convert (in JSON-LD)")
+
+    verify()
+  }
+
+  // Parse command line arguments.
+  val conf = new Conf(args, logger)
+
+  // Which files do we need to process?
+  val dataFiles = conf.data()
+
+  // Process!
+  dataFiles.foreach(CORDJsonReader.processFile(_, logger))
+}

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -11,6 +11,7 @@ import org.rogach.scallop.exceptions._
 import zamblauskas.csv.parser.Parser
 import zamblauskas.csv.parser._
 
+import scala.collection.parallel.immutable.ParSeq
 import scala.io.Source
 
 object RoboCORD extends App with LazyLogging {
@@ -36,7 +37,7 @@ object RoboCORD extends App with LazyLogging {
     )
     val output: ScallopOption[File] = opt[File](
       descr = "Directory where report should be written",
-      default = Some(new File("robocord-results"))
+      default = Some(new File("robocord-output"))
     )
     val neo4jLocation: ScallopOption[File] = opt[File](
       descr = "Location of the Neo4J database that SciGraph should use.",
@@ -90,7 +91,7 @@ object RoboCORD extends App with LazyLogging {
 
   // Summarize all files into the output directory.
   // .par(conf.parallel())
-  val results = wrappedData.par.map(wrappedArticle => {
+  val results: ParSeq[String] = wrappedData.par.flatMap(wrappedArticle => {
     // Step 1. Find the metadata for this article.
     val metadataEntry = metadataMap.get(wrappedArticle.sha1).head.head
 

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -1,0 +1,35 @@
+package org.renci.robocord.annotator
+
+import java.io.{File, StringReader}
+import java.util.HashMap
+
+import io.scigraph.annotation.{EntityAnnotation, EntityFormatConfiguration, EntityProcessorImpl, EntityRecognizer}
+import io.scigraph.neo4j.NodeTransformer
+import io.scigraph.vocabulary.{Vocabulary, VocabularyNeo4jImpl}
+import org.apache.lucene.queryparser.classic.QueryParserBase
+import org.neo4j.graphdb.GraphDatabaseService
+import org.neo4j.graphdb.factory.GraphDatabaseFactory
+import org.prefixcommons.CurieUtil
+import scala.collection.JavaConverters._
+
+/** Methods for extracting annotations from text using SciGraph */
+class Annotator(neo4jLocation: File) {
+  private val curieUtil: CurieUtil         = new CurieUtil(new HashMap())
+  private val transformer: NodeTransformer = new NodeTransformer()
+  private val graphDB: GraphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase(neo4jLocation)
+  private val vocabulary: Vocabulary = new VocabularyNeo4jImpl(graphDB, neo4jLocation.getAbsolutePath, curieUtil, transformer)
+  private val recognizer = new EntityRecognizer(vocabulary, curieUtil)
+
+  val processor = new EntityProcessorImpl(recognizer)
+
+  def dispose(): Unit = graphDB.shutdown()
+
+  /** Extract annotations from a particular string using SciGraph. */
+  def extractAnnotations(str: String): List[EntityAnnotation] = {
+    val configBuilder =
+      new EntityFormatConfiguration.Builder(new StringReader(QueryParserBase.escape(str)))
+        .longestOnly(true)
+        .minLength(3)
+    processor.annotateEntities(configBuilder.get).asScala.toList
+  }
+}

--- a/src/main/scala/org/renci/robocord/json/CORDJsonReader.scala
+++ b/src/main/scala/org/renci/robocord/json/CORDJsonReader.scala
@@ -101,9 +101,9 @@ class CORDArticleWrapper(article: Article) {
 }
 
 object CORDJsonReader {
-  def wrapFileOrDir(file: File, logger: Logger): Seq[CORDArticleWrapper] = {
-    if (file.isDirectory) file.listFiles.flatMap(wrapFileOrDir(_, logger))
-    else if (file.getName.toLowerCase.endsWith(".json")) {
+  def wrapFileOrDir(file: File, logger: Logger, shasToLoadLowercase: Set[String]): Seq[CORDArticleWrapper] = {
+    if (file.isDirectory) file.listFiles.flatMap(wrapFileOrDir(_, logger, shasToLoadLowercase))
+    else if (file.getName.toLowerCase.endsWith(".json") && shasToLoadLowercase.contains(file.getName.toLowerCase.replace(".json", ""))) {
       val source = Source.fromFile(file)
       val content = source.mkString
       source.close

--- a/src/main/scala/org/renci/robocord/json/CORDJsonReader.scala
+++ b/src/main/scala/org/renci/robocord/json/CORDJsonReader.scala
@@ -1,0 +1,108 @@
+package org.renci.robocord.json
+
+import java.io.File
+
+import com.typesafe.scalalogging.Logger
+import io.circe._
+import io.circe.parser._
+import io.circe.generic.auto._
+import io.circe.syntax._
+
+import scala.io.Source
+
+case class Location(
+  postCode: Option[String],
+  settlement: Option[String],
+  region: Option[String],
+  country: Option[String]
+)
+
+case class Affiliation(
+  laboratory: Option[String],
+  institution: Option[String],
+  location: Option[Location]
+)
+
+case class Author(
+  first: String,
+  middle: Seq[String],
+  last: String,
+  suffix: String,
+  affiliation: Option[Affiliation],
+  email: Option[String]
+)
+
+case class ArticleMetadata(
+  title: String,
+  authors: Seq[Author]
+)
+
+case class ArticleRef(
+  start: Option[Int],
+  end: Option[Int],
+  text: Option[String],
+  ref_id: Option[String]
+)
+
+case class ArticleAbstract(
+  section: String,
+  text: String,
+  cite_spans: Seq[ArticleRef],
+  ref_spans: Seq[ArticleRef]
+)
+
+case class ArticleBodyText(
+  section: String,
+  text: String,
+  cite_spans: Seq[ArticleRef],
+  ref_spans: Seq[ArticleRef],
+  eq_spans: Option[Seq[ArticleRef]]
+)
+
+case class ArticleRefEntry(
+  text: String,
+  `type`: String
+)
+
+case class ArticleBibEntry(
+  ref_id: String,
+  title: String,
+  authors: Seq[Author],
+  year: Option[Int],
+  venue: String,
+  volume: String,
+  issn: String,
+  pages: String,
+  other_ids: Map[String, Seq[String]]
+)
+
+case class Article(
+  paper_id: String,
+  metadata: ArticleMetadata,
+  `abstract`: Seq[ArticleAbstract],
+  body_text: Seq[ArticleBodyText],
+  bib_entries: Map[String, ArticleBibEntry],
+  ref_entries: Map[String, ArticleRefEntry],
+  back_matter: Seq[ArticleBodyText]
+)
+
+object CORDJsonReader {
+  def processFile(file: File, logger: Logger): Unit = {
+    if (file.isDirectory) file.listFiles.foreach(processFile(_, logger))
+    else if (file.getName.toLowerCase.endsWith(".json")) {
+      logger.info("Started processing file " + file)
+
+      val source = Source.fromFile(file)
+      val content = source.mkString
+      decode[Article](content) match {
+        case Right(article) => {
+          logger.info("Parsed article successfully!")
+        }
+        case Left(ex) => {
+          logger.error(s"COULD NOT PARSE $file: $ex")
+        }
+      }
+      source.close
+    }
+  }
+}

--- a/src/main/scala/org/renci/robocord/json/CORDJsonReader.scala
+++ b/src/main/scala/org/renci/robocord/json/CORDJsonReader.scala
@@ -93,11 +93,13 @@ class CORDArticleWrapper(article: Article) {
   val titleText = article.metadata.title
   val abstractText = article.`abstract`.map(_.text).mkString("\n")
   val bodyText = article.body_text.map(_.text).mkString("\n")
+  val refText = article.ref_entries.values.map(_.text).mkString("\n")
+  val backText = article.back_matter.map(_.text).mkString("\n")
 
-  def getSciGraphAnnotations(ann: Annotator): Seq[EntityAnnotation] =
-    ann.extractAnnotations(
-      s"$titleText\n$abstractText\n$bodyText"
-    )
+  /** Returns the full text of this article */
+  def fullText: String = s"$titleText\n$abstractText\n$bodyText\n$refText\n$backText"
+
+  def getSciGraphAnnotations(ann: Annotator): Seq[EntityAnnotation] = ann.extractAnnotations(fullText)._2
 }
 
 object CORDJsonReader {


### PR DESCRIPTION
This PR updates the Makefile to download the [COVID-19 Open Research Dataset](https://pages.semanticscholar.org/coronavirus-research), and a Scala program to read through the metadata file, scan all titles and abstracts and (where possible) full-text files in JSON using the same SciGraph settings we use for Omnicorp. Closes #56.

This program is designed to work with a SLURM job array. You can call `robocord.job` as a job array from 0 to the number of jobs you want to break the job up into. It divides the rows in the metadata.csv file into that much chunks, and each SLURM job uses its array number to determine which chunk it needs to work on.

This is currently untested, but since we can't really test it without a SciGraph instance, I'll worry about testing it later.