### PR TITLE
Added program to convert output to TSV

### DIFF
--- a/generate-tsv.job
+++ b/generate-tsv.job
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 #SBATCH --job-name=OmnicorpTSV
-#SBATCH --output=tsv-output/log-output-%a.txt
-#SBATCH --error=tsv-output/log-error-%a.txt
+#SBATCH --output=tsv-output/log-output-%A.txt
+#SBATCH --error=tsv-output/log-error-%A.txt
 #SBATCH --cpus-per-task 40
 #SBATCH --mem=50000
 #SBATCH --time=12:00:00

--- a/generate-tsv.job
+++ b/generate-tsv.job
@@ -3,7 +3,7 @@
 #SBATCH --job-name=OmnicorpTSV
 #SBATCH --output=tsv-output/log-output-%A.txt
 #SBATCH --error=tsv-output/log-error-%A.txt
-#SBATCH --cpus-per-task 40
+#SBATCH --cpus-per-task 32
 #SBATCH --mem=50000
 #SBATCH --time=12:00:00
 #SBATCH --mail-user=gaurav@renci.org

--- a/generate-tsv.job
+++ b/generate-tsv.job
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+#SBATCH --job-name=OmnicorpTSV
+#SBATCH --output=tsv-output/log-output-%a.txt
+#SBATCH --error=tsv-output/log-error-%a.txt
+#SBATCH --cpus-per-task 40
+#SBATCH --mem=50000
+#SBATCH --time=12:00:00
+#SBATCH --mail-user=gaurav@renci.org
+
+set -e # Exit immediately if a pipeline fails.
+
+export JAVA_OPTS="-Xmx50G"
+
+echo "Starting GenerateTSV, writing outputs to tsv-output/"
+sbt "runMain org.renci.chemotext.GenerateTSV"
+echo "Processing complete."

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -1,0 +1,78 @@
+package org.renci.chemotext
+
+import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
+import java.nio.file.{Files, Paths, StandardCopyOption}
+import java.time.Duration
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.riot.RDFDataMgr
+import org.apache.jena.vocabulary.{DCTerms, RDF}
+
+/**
+ * GenerateTSV generates tab-delimited files summarizing the results of the
+ * Omnicorp processing.
+ */
+object GenerateTSV extends App with LazyLogging {
+  // List of files to process and output directory.
+  // TODO replace with command line argument.
+  val files: Seq[File] = Seq(new File("output"))
+  val outputDir: File = new File("tsv-output")
+
+  /**
+   * Extract PubMed articles and results from the input file.
+   */
+  def writeTSVToDir(inputFile: File, outputDir: File): Unit = {
+    if (inputFile.isDirectory) {
+      logger.info(s"Recursing into directory $inputFile")
+      inputFile.listFiles.filter(_.getName.toLowerCase.endsWith(".gz.ttl")).foreach(writeTSVToDir(_, outputDir))
+    } else {
+      logger.info(s"Processing file $inputFile")
+
+      val startTime = System.nanoTime
+
+      val dataModel = RDFDataMgr.loadModel(inputFile.toURI.toString)
+      val infModel = ModelFactory.createRDFSModel(dataModel)
+      val articles = infModel.listResourcesWithProperty(
+        RDF.`type`,
+        infModel.createResource("http://purl.org/spar/fabio/Article")
+      )
+
+      // Check to see if we've already completed processing this file.
+      val completedFilename = new File(outputDir, inputFile.getName + ".tsv")
+      if (completedFilename.exists) {
+        logger.info(s"Skipping, since $completedFilename already exists.")
+      } else {
+        // Start creating an in-progress file.
+        val outputFilename = new File(outputDir, inputFile.getName + ".in-progress.tsv")
+        val outputStream = new PrintWriter(new BufferedWriter(new FileWriter(outputFilename)))
+
+        var articleCount = 0
+        articles.forEachRemaining(article => {
+          articleCount += 1
+          val refs = infModel.listObjectsOfProperty(article, DCTerms.references)
+          refs.forEachRemaining(ref => {
+            outputStream.println(article.getURI + "\t" + ref.asResource.getURI)
+          })
+        })
+        outputStream.close()
+
+        val duration = Duration.ofNanos(System.nanoTime - startTime)
+
+        val articlesPerSecond = (articleCount.toFloat / duration.getSeconds)
+        logger.info(f"Took ${duration.getSeconds} seconds ($duration) to process $articleCount ($articlesPerSecond%.2f articles/sec) from $inputFile to $outputFilename")
+
+        // Rename file to completed.
+        Files.move(
+          Paths.get(outputFilename.toURI),
+          Paths.get(completedFilename.toURI),
+          StandardCopyOption.ATOMIC_MOVE,
+          StandardCopyOption.REPLACE_EXISTING
+        )
+      }
+    }
+  }
+
+  // Process files.
+  files.foreach(writeTSVToDir(_, outputDir))
+}

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -63,7 +63,7 @@ object GenerateTSV extends App with LazyLogging {
         val duration = Duration.ofNanos(System.nanoTime - startTime)
 
         val articlesPerSecond = (articleCount.toFloat / duration.getSeconds)
-        logger.info(f"Took ${duration.getSeconds} seconds ($duration) to process $articleCount ($articlesPerSecond%.2f articles/sec) from $inputFile to $outputFilename")
+        logger.info(f"Took ${duration.getSeconds} seconds ($duration) to process $articleCount articles ($articlesPerSecond%.2f articles/sec) from $inputFile to $outputFilename")
 
         // Rename file to completed.
         Files.move(

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -25,7 +25,10 @@ object GenerateTSV extends App with LazyLogging {
   def writeTSVToDir(inputFile: File, outputDir: File): Unit = {
     if (inputFile.isDirectory) {
       logger.info(s"Recursing into directory $inputFile")
-      inputFile.listFiles.filter(_.getName.toLowerCase.endsWith(".gz.ttl")).par.foreach(writeTSVToDir(_, outputDir))
+      inputFile.listFiles.filter(file =>
+        file.getName.toLowerCase.endsWith(".gz.ttl") ||
+        file.getName.toLowerCase.endsWith(".gz.completed.ttl")
+      ).par.foreach(writeTSVToDir(_, outputDir))
     } else {
       logger.info(s"Processing file $inputFile")
 

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -25,7 +25,7 @@ object GenerateTSV extends App with LazyLogging {
   def writeTSVToDir(inputFile: File, outputDir: File): Unit = {
     if (inputFile.isDirectory) {
       logger.info(s"Recursing into directory $inputFile")
-      inputFile.listFiles.filter(_.getName.toLowerCase.endsWith(".gz.ttl")).foreach(writeTSVToDir(_, outputDir))
+      inputFile.listFiles.filter(_.getName.toLowerCase.endsWith(".gz.ttl")).par.foreach(writeTSVToDir(_, outputDir))
     } else {
       logger.info(s"Processing file $inputFile")
 


### PR DESCRIPTION
This PR adds a new program (GenerateTSV) which extracts all the dct:references terms from the Omnicorp output. It does this by loading each output file using Jena. It runs this task in parallel across all the available processors, but doesn't do anything else to parallelize across clusters. It takes around 1-2 hours to run on the RENCI cluster.