### PR TITLE
Add support for PMC JSON files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MEMORY = 16G
 PARALLEL = 4
 
 # The date of CORD-19 data to download.
-ROBOCORD_DATE="2020-03-27"
+ROBOCORD_DATE="2020-04-17"
 
 .PHONY: all
 all: output

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: coursier output
 # RoboCORD
 .PHONY: robocord-download robocord-output robocord-test
 robocord-download:
-	# robocord-data is intended to be a symlink to robocord-datas/$ROBOCORD_DATE, so that it is updated automatically. 
+	# robocord-data is intended to be a symlink to robocord-datas/${ROBOCORD_DATE}, so that it is updated automatically. 
 	# If robocord-data doesn't exist or is a symlink, we update it
 	# automatically. Otherwise (i.e. if it's an existing directory),
 	# we only update the files already in it.
@@ -86,6 +86,12 @@ robocord-output: robocord-data SciGraph
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv robocord-data"
 
 robocord-test: SciGraph
+	@if [ ! -e robocord-output ] || [ -L robocord-output ]; then \
+		rm robocord-output; \
+		mkdir -p robocord-outputs/${ROBOCORD_DATE}; \
+		ln -s robocord-outputs/${ROBOCORD_DATE} robocord-output; \
+	fi
+
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 4 --total-chunks 1000 robocord-data"
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 5 --total-chunks 1000 robocord-data"
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 6 --total-chunks 1000 robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ robocord-output: robocord-data SciGraph
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv robocord-data"
 
 robocord-test: SciGraph
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 0 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 1 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 2 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 3 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 4 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 5 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 6 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 437 --total-chunks 1000 robocord-data"

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -131,13 +131,13 @@ object RoboCORD extends App with LazyLogging {
     val (fullText, withFullText) = if (pmcid.nonEmpty && fullTextById.contains(pmcid)) {
       // Retrieve the full text.
       (
-        fullTextById.getOrElse(pmcid, Seq()).map(_.fullText).mkString("\n===\n"),
+        fullTextById.getOrElse(pmcid, Seq.empty).map(_.fullText).mkString("\n===\n"),
         s"with full text from PMCID $pmcid"
       )
     } else if (sha.nonEmpty && fullTextById.contains(sha)) {
       // Retrieve the full text.
       (
-        fullTextById.getOrElse(sha, Seq()).map(_.fullText).mkString("\n===\n"),
+        fullTextById.getOrElse(sha, Seq.empty).map(_.fullText).mkString("\n===\n"),
         s"with full text from SHA $sha"
       )
     } else {

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -124,19 +124,25 @@ object RoboCORD extends App with LazyLogging {
     val abstractText = entry.getOrElse("abstract", "")
 
     // Is there a full text article for this entry?
-    val fullText: String = if (pmcid.nonEmpty && fullTextById.contains(pmcid)) {
+    val (fullText, withFullText) = if (pmcid.nonEmpty && fullTextById.contains(pmcid)) {
       // Retrieve the full text.
-      fullTextById.getOrElse(pmcid, Seq()).map(_.fullText).mkString("\n===\n")
+      (
+        fullTextById.getOrElse(pmcid, Seq()).map(_.fullText).mkString("\n===\n"),
+        s"with full text from PMCID $pmcid"
+      )
     } else if (sha.nonEmpty && fullTextById.contains(sha)) {
       // Retrieve the full text.
-      fullTextById.getOrElse(sha, Seq()).map(_.fullText).mkString("\n===\n")
+      (
+        fullTextById.getOrElse(sha, Seq()).map(_.fullText).mkString("\n===\n"),
+        s"with full text from SHA $sha"
+      )
     } else {
       // We don't have full text, so just annotate the title and abstract.
-      s"$title\n$abstractText"
+      (
+        s"$title\n$abstractText",
+        "without full text"
+      )
     }
-    val withFullText = if (pmcid.nonEmpty && fullTextById.contains(pmcid)) s"with full text from PMCID $pmcid"
-      else if (sha.nonEmpty && fullTextById.contains(sha)) s"with full text from SHA $sha"
-      else "without full text"
 
     val (parsedFullText, annotations) = annotator.extractAnnotations(fullText.replaceAll("\\s+", " "))
 

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -117,7 +117,10 @@ object RoboCORD extends App with LazyLogging {
       logger.info(s"Found multiple PMCIDs for $id, choosing the last one ($pmcidLast) out of: $pmcids")
       pmcidLast
     } else pmcids.headOption.getOrElse("")
-    val articleId = pmid.map("PMID:" + _).getOrElse(doi.map("DOI:" + _).getOrElse("PMCID:" + pmcid))
+    val articleId = if (pmid.nonEmpty && pmid.get.nonEmpty) pmid.map("PMID:" + _).mkString("|")
+      else if(doi.nonEmpty && doi.get.nonEmpty) doi.map("DOI:" + _).mkString("|")
+      else if(pmcid.nonEmpty) pmcid.map("PMCID:" + _)
+      else s"CORD_UID:$id"
 
     // Get article.
     val title: String = entry.getOrElse("title", "")

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -83,8 +83,8 @@ object RoboCORD extends App with LazyLogging {
   logger.info(s"Selected $articlesTotal articles for processing (from $startIndex until $endIndex, chunk $currentChunk out of $totalChunks)")
 
   // Identify full text SHAs and PMCIDs in the current chunk (`metadata`).
-  val shasToLoad = metadata.map(_.get("sha")).flatten.flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
-  val pmcIdsToLoad = metadata.map(_.get("pmcid")).flatten.flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
+  val shasToLoad = metadata.flatMap(_.get("sha")).flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
+  val pmcIdsToLoad = metadata.flatMap(_.get("pmcid")).flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
   // logger.info(s"shasToLoad: $shasToLoad")
   // logger.info(s"pmcIdsToLoad: $pmcIdsToLoad")
 


### PR DESCRIPTION
This PR adds support for PMC JSON files, which are in (almost) the same format as the PDF JSON files. We prioritize PMC JSON files over PDF JSON files when both are present. This PR also adds support for creating a new robocord-output directory when needed.