### PR TITLE
Modified ORCID generation so that invalid ORCIDs are skipped

### DIFF
--- a/src/main/scala/org/renci/chemotext/AuthorWrapper.scala
+++ b/src/main/scala/org/renci/chemotext/AuthorWrapper.scala
@@ -2,8 +2,11 @@ package org.renci.chemotext
 
 import scala.xml.Node
 import scala.collection.immutable
-import java.net.{URI, URISyntaxException}
+import java.net.URI
+
 import com.typesafe.scalalogging.LazyLogging
+
+import scala.util.Try
 
 /** Author name management. */
 class AuthorWrapper(node: Node) extends LazyLogging {
@@ -29,16 +32,9 @@ class AuthorWrapper(node: Node) extends LazyLogging {
     .map("https://orcid.org/" + _.trim)
     .filter(orcid => {
       // Make sure we have a valid URI. If not, skip this.
-      try {
-        new URI(orcid)
-        true;
-      } catch {
-        case ex: URISyntaxException => {
-          logger.warn(s"Skipping unreadable ORCID '${orcid}' for author ${name}: ${ex}")
-          false;
-        }
-        case _: Throwable => false;
-      }
+      val result = Try(new URI(orcid))
+      if (result.isFailure) logger.warn(s"Skipping unreadable ORCID '${orcid}' for author ${name}")
+      result.isSuccess
     })
 
   // FOAF uses foaf:givenName and foaf:familyName.

--- a/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
+++ b/src/test/scala/org/renci/chemotext/PubMedArticleWrapperUnitTests.scala
@@ -49,6 +49,24 @@ object PubMedArticleWrapperUnitTests extends TestSuite {
           </Author>).orcIds
           assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
         }
+        test("ORCID with HTTPS URL") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">https://orcid.org/0000-0003-0587-0454</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq("https://orcid.org/0000-0003-0587-0454"))
+        }
+        test("Malformed ORCIDs") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">orcid"&gt;0000-0002-9335-1218</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq())
+        }
+        test("Truncated ORCIDs") {
+          val orcids = new AuthorWrapper(<Author>
+            <Identifier Source="ORCID">0000-0002-9335-121</Identifier>
+          </Author>).orcIds
+          assert(orcids == Seq())
+        }
       }
     }
     test("PubMedArticleWrapper") {


### PR DESCRIPTION
We were previously trusting in the ORCID field to include a valid ORCID, which we use to construct an URI. This PR adds a test to ensure that it is a valid URI. If not, the ORCID is considered to be malformed and ignored.