### PR TITLE
Added check for output file, preventing redos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ PARALLEL = 4
 
 # The date of CORD-19 data to download.
 ROBOCORD_DATE="2020-08-30"
-
 .PHONY: all
 all: output
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ robocord-test: SciGraph
 		ln -s robocord-outputs/${ROBOCORD_DATE} robocord-output; \
 	fi
 
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 4 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 5 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 6 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 437 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 640 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 768  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 896  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55936 --until-row 56064 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 140776 --until-row 141109 robocord-data"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@
 
 Extract ontology terms referenced from PubMed abstracts as per the [MEDLINE/PubMed Baseline Repository](https://mbr.nlm.nih.gov/) by using [SciGraph](https://github.com/SciGraph/SciGraph) against a set of ontologies.
 
-## Ontologies
+# OmniCORD
+
+Extract ontology terms used in the [COVID-19 Open Research Dataset (CORD)](https://www.semanticscholar.org/cord19) as tab-delimited files for further processing in [COVID-KOP](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7316095/).
+
+In order to generate OmniCORD output files, you should:
+1. Use `robocord.job` to attempt to run all the jobs on a SLURM cluster.
+   Any number of jobs can be specified, but values of around 4000 seem
+   to work with. Example: `sbatch --array=0-3999 robocord.job`.
+2. Use RoboCORDManager to re-run any jobs that failed to complete. You can
+   use the `--dry-run` option to see what jobs will be executed before they
+   are run. Jobs are executed using the `robocord-sbatch.sh` script, so
+   modify that if necessary.
+   Example: `srun sbt "runMain org.renci.robocord.RoboCORDManager --job-size 20`
+
+# Ontologies used
 Currently, we look for terms from the following ontologies:
 * [Uberon (base)](http://uberon.org) ([OWL](http://purl.obolibrary.org/obo/uberon/uberon-base.owl))
 * [ChEBI](https://www.ebi.ac.uk/chebi/) ([OWL](http://purl.obolibrary.org/obo/chebi.owl))

--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,16 @@ libraryDependencies ++= {
     "org.scala-lang.modules"      %% "scala-xml"              % "1.0.6",
     "io.scigraph"                 %  "scigraph-core"          % "2.1-SNAPSHOT",
     "io.scigraph"                 %  "scigraph-entity"        % "2.1-SNAPSHOT",
-    "com.typesafe.scala-logging"  %% "scala-logging"          % "3.7.1",
-    "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
     "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
+
+    // Testing
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test",
+
+    // Logging
+    "com.typesafe.scala-logging"  %% "scala-logging"          % "3.7.1",
+    "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
+    "com.outr"                    %% "scribe"                 % "2.7.3",
 
     // Command line argument parsing.
     "org.rogach"                  %% "scallop"                % "3.3.2",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ wartremoverWarnings ++= Warts.unsafe
 
 javaOptions += "-Xmx20G"
 
-fork in Test := true
+fork := true
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 

--- a/robocord-sbatch.sh
+++ b/robocord-sbatch.sh
@@ -10,7 +10,7 @@ sbatch <<EOT
 #SBATCH --error=robocord-output/log-error-%A.txt
 #SBATCH --cpus-per-task 16
 #SBATCH --mem=50000
-#SBATCH --time=12:00:00
+#SBATCH --time=2:00:00
 #SBATCH --mail-user=gaurav@renci.org
 
 set -e # Exit immediately if a pipeline fails.

--- a/robocord-sbatch.sh
+++ b/robocord-sbatch.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# All arguments are passed on to the RoboCORD instance.
+
+sbatch <<EOT
+#!/bin/bash
+#
+#SBATCH --job-name=RoboCORD
+#SBATCH --output=robocord-output/log-output-%a.txt
+#SBATCH --error=robocord-output/log-error-%a.txt
+#SBATCH --cpus-per-task 16
+#SBATCH --mem=50000
+#SBATCH --time=12:00:00
+#SBATCH --mail-user=gaurav@renci.org
+
+set -e # Exit immediately if a pipeline fails.
+
+export JAVA_OPTS="-Xmx50G"
+export MY_SCIGRAPH=omnicorp-scigraph-\$SLURM_ARRAY_TASK_ID
+
+echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
+cp -R omnicorp-scigraph "scigraphs/\$MY_SCIGRAPH"
+
+echo "Starting RoboCORD with argumnets: $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
+sbt "runMain org.renci.robocord.RoboCORD $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
+
+rm -rf "scigraphs/\$MY_SCIGRAPH"
+echo "Deleted duplicated omnicorp-scigraph"
+EOT

--- a/robocord-sbatch.sh
+++ b/robocord-sbatch.sh
@@ -6,8 +6,8 @@ sbatch <<EOT
 #!/bin/bash
 #
 #SBATCH --job-name=RoboCORD
-#SBATCH --output=robocord-output/log-output-%a.txt
-#SBATCH --error=robocord-output/log-error-%a.txt
+#SBATCH --output=robocord-output/log-output-%A.txt
+#SBATCH --error=robocord-output/log-error-%A.txt
 #SBATCH --cpus-per-task 16
 #SBATCH --mem=50000
 #SBATCH --time=12:00:00
@@ -16,13 +16,13 @@ sbatch <<EOT
 set -e # Exit immediately if a pipeline fails.
 
 export JAVA_OPTS="-Xmx50G"
-export MY_SCIGRAPH=omnicorp-scigraph-\$SLURM_ARRAY_TASK_ID
+export MY_SCIGRAPH=omnicorp-scigraph-\$SLURM_JOB_ID
 
 echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
 cp -R omnicorp-scigraph "scigraphs/\$MY_SCIGRAPH"
 
-echo "Starting RoboCORD with argumnets: $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
-sbt "runMain org.renci.robocord.RoboCORD $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
+echo "Starting RoboCORD with arguments: --neo4j-location scigraphs/\$MY_SCIGRAPH $@"
+sbt "runMain org.renci.robocord.RoboCORD --neo4j-location scigraphs/\$MY_SCIGRAPH $@"
 
 rm -rf "scigraphs/\$MY_SCIGRAPH"
 echo "Deleted duplicated omnicorp-scigraph"

--- a/robocord.job
+++ b/robocord.job
@@ -26,7 +26,7 @@ else
     cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
 
     echo "Starting RoboCORD from row $FROM_ROW until $UNTIL_ROW."
-    sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row $FROM_ROW --until-row $UNTIL_ROW --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+    sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row $FROM_ROW --until-row $UNTIL_ROW --output-prefix robocord-output/result --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
 
     rm -rf "scigraphs/$MY_SCIGRAPH"
     echo "Deleted duplicated omnicorp-scigraph"

--- a/robocord.job
+++ b/robocord.job
@@ -13,7 +13,7 @@ set -e # Exit immediately if a pipeline fails.
 export JAVA_OPTS="-Xmx50G"
 export MY_SCIGRAPH=omnicorp-scigraph-$SLURM_ARRAY_TASK_ID
 
-export METADATA_SIZE=$(($(wc -l < robocord-data/metadata.csv) - 1))
+export METADATA_SIZE=$(wc -l < robocord-data/metadata.csv)
 export CHUNK_SIZE=$(($METADATA_SIZE/$SLURM_ARRAY_TASK_MAX))
 export FROM_ROW=$(($SLURM_ARRAY_TASK_ID * $CHUNK_SIZE))
 export UNTIL_ROW=$(($FROM_ROW + $CHUNK_SIZE))

--- a/robocord.job
+++ b/robocord.job
@@ -5,7 +5,7 @@
 #SBATCH --error=robocord-output/log-error-%a.txt
 #SBATCH --cpus-per-task 16
 #SBATCH --mem=50000
-#SBATCH --time=12:00:00
+#SBATCH --time=4:00:00
 #SBATCH --mail-user=gaurav@renci.org
 
 set -e # Exit immediately if a pipeline fails.
@@ -13,11 +13,21 @@ set -e # Exit immediately if a pipeline fails.
 export JAVA_OPTS="-Xmx50G"
 export MY_SCIGRAPH=omnicorp-scigraph-$SLURM_ARRAY_TASK_ID
 
-echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
-cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
+export METADATA_SIZE=$(($(wc -l < robocord-data/metadata.csv) - 1))
+export CHUNK_SIZE=$(($METADATA_SIZE/$SLURM_ARRAY_TASK_MAX))
+export FROM_ROW=$(($SLURM_ARRAY_TASK_ID * $CHUNK_SIZE))
+export UNTIL_ROW=$(($FROM_ROW + $CHUNK_SIZE))
+export OUTPUT_FILENAME=robocord-output/result_from_${FROM_ROW}_until_${UNTIL_ROW}.tsv
 
-echo "Starting RoboCORD"
-sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk $SLURM_ARRAY_TASK_ID --total-chunks $SLURM_ARRAY_TASK_MAX --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+if [ -f $OUTPUT_FILENAME ]; then
+    echo Output filename $OUTPUT_FILENAME already exists, skipping.
+else
+    echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
+    cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
 
-rm -rf "scigraphs/$MY_SCIGRAPH"
-echo "Deleted duplicated omnicorp-scigraph"
+    echo "Starting RoboCORD from row $FROM_ROW until $UNTIL_ROW."
+    sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row $FROM_ROW --until-row $UNTIL_ROW --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+
+    rm -rf "scigraphs/$MY_SCIGRAPH"
+    echo "Deleted duplicated omnicorp-scigraph"
+fi

--- a/robocord.job
+++ b/robocord.job
@@ -1,5 +1,10 @@
 #!/bin/bash
 #
+# This script should be run:
+#   sbatch --array=0-3999 robocord.job
+# Where the total number of jobs (3999 in the example above) can be
+# any number.
+#
 #SBATCH --job-name=RoboCORD
 #SBATCH --output=robocord-output/log-output-%a.txt
 #SBATCH --error=robocord-output/log-error-%a.txt

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -102,7 +102,7 @@ object RoboCORD extends App with LazyLogging {
   val endIndex: Int = startIndex + chunkLength
 
   // Do we already have an output file? If so, we abort.
-  val inProgressFilename = "in-progress." + conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
+  val inProgressFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.in-progress.txt"
   if (new File(inProgressFilename).exists()) {
     if (new File(inProgressFilename).delete())
       logger.info(s"In-progress output file '${inProgressFilename}' already exists and has been deleted.")

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -35,7 +35,7 @@ object RoboCORD extends App with LazyLogging {
       default = Some(new File("robocord-data/all_sources_metadata_latest.csv"))
     )
     val outputPrefix: ScallopOption[String] = opt[String](
-      descr = "Prefix for the filename (we will add '_from_<start index>_until_<end index>.txt' to the filename)",
+      descr = "Prefix for the filename (we will add '_from_<start index>_until_<end index>.tsv' to the filename)",
       default = Some("robocord-output/result")
     )
     val neo4jLocation: ScallopOption[File] = opt[File](
@@ -109,7 +109,7 @@ object RoboCORD extends App with LazyLogging {
     }
   }
 
-  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
+  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.tsv"
   if (new File(outputFilename).length > 0) {
     logger.info(s"Output file '${outputFilename}' already exists, skipping.")
     System.exit(0)

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -100,6 +100,13 @@ object RoboCORD extends App with LazyLogging {
   val startIndex: Int = currentChunk * chunkLength
   val endIndex: Int = startIndex + chunkLength
 
+  // Do we already have an output file? If so, we abort.
+  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
+  if (new File(outputFilename).length > 0) {
+    logger.info(s"Output file '${outputFilename}' already exists, skipping.")
+    System.exit(0);
+  }
+
   // Divide allMetadata into chunks based on totalChunks.
   val metadata: Seq[Map[String, String]] = allMetadata.slice(startIndex, endIndex)
   val articlesTotal = metadata.size
@@ -181,7 +188,6 @@ object RoboCORD extends App with LazyLogging {
   })
 
   // Write out all the results to the output file.
-  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
   logger.info(s"Writing tab-delimited output to $outputFilename.")
   val pw = new PrintWriter(new FileWriter(new File(outputFilename)))
   results.foreach(pw.println(_))

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -145,7 +145,7 @@ object RoboCORD extends App with LazyLogging {
     // Choose an "article ID", which is one of: (1) PubMed ID, (2) DOI, (3) PMCID or (4) CORD_UID.
     val articleId = if (pmid.nonEmpty && pmid.get.nonEmpty) pmid.map("PMID:" + _).mkString("|")
       else if(doi.nonEmpty && doi.get.nonEmpty) doi.map("DOI:" + _).mkString("|")
-      else if(pmcid.nonEmpty) pmcid.map("PMCID:" + _)
+      else if(pmcid.nonEmpty) s"PMCID:${pmcid}"
       else s"CORD_UID:$id"
 
     // Full-text articles are stored by path. We might have multiple PMC or PDF parses; we prioritize PMC over PDF.

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -107,6 +107,14 @@ object RoboCORDManager extends App {
   }
   scribe.info(s"Ranges to process: ${rangesToProcess.mkString(", ")}")
 
+  // Generate warnings for overlapping output files.
+  val existingRanges = existingRangesSorted.toSet
+  existingRanges.foreach(range => {
+    existingRanges.filter(r => r != range && r.intersect(range).nonEmpty).foreach(r => {
+      scribe.warn(s"Output files are present for both ${range} and ${r}")
+    })
+  })
+
   // Okay, now we know the ranges that need to be processed. We divide them up into jobs recursively.
   var jobCount = 0
   def processJob(range: Range): Unit = {

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -115,6 +115,10 @@ object RoboCORDManager extends App {
     })
   })
 
+  if (rangesToProcess.isEmpty) {
+    scribe.info("No ranges remain to be processed. No jobs need to be created.")
+  }
+
   // Okay, now we know the ranges that need to be processed. We divide them up into jobs recursively.
   var jobCount = 0
   def processJob(range: Range): Unit = {

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -73,12 +73,12 @@ object RoboCORDManager extends App {
   scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
 
   // Get all existing output files.
-  val filenameRegex = """results_from_(\d+)_until_(\d+).txt""".r
+  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
   val existingRangesSorted: Seq[Range] = conf.outputDir
     .getOrElse(new File("robocord-output"))
     .listFiles()
     .toSeq
-    .filter(file => file.getName.startsWith("results_") && file.getName.endsWith(".txt"))
+    .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
     .map(file => file.getName match {
       case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
       case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
@@ -138,7 +138,7 @@ object RoboCORDManager extends App {
           "--metadata", "robocord-data/metadata.csv",
           "--from-row", range.start.toString,
           "--until-row", range.end.toString,
-          "--output-prefix", "robocord-output/results",
+          "--output-prefix", "robocord-output/result",
           "robocord-data"
         )
         val process = cmd.run(logger)

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -52,7 +52,7 @@ object RoboCORDManager extends App {
       descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
       default = Some(false)
     )
-    val tryOnce: ScallopOption[Boolean] = opt[Boolean](
+    val tryOne: ScallopOption[Boolean] = opt[Boolean](
       descr = "If true, try executing a single job.",
       default = Some(false)
     )
@@ -146,7 +146,7 @@ object RoboCORDManager extends App {
           scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size}): ${cmd}")
         else
           scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
-        if(conf.tryOnce.getOrElse(false)) System.exit(0)
+        if(conf.tryOne.getOrElse(false)) System.exit(0)
         TimeUnit.SECONDS.sleep(conf.cmdDelay.getOrElse(2))
       }
     }

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -52,7 +52,7 @@ object RoboCORDManager extends App {
       descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
       default = Some(false)
     )
-    val tryOne: ScallopOption[Boolean] = opt[Boolean](
+    val tryOnce: ScallopOption[Boolean] = opt[Boolean](
       descr = "If true, try executing a single job.",
       default = Some(false)
     )
@@ -134,7 +134,7 @@ object RoboCORDManager extends App {
           scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size}): ${cmd}")
         else
           scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
-        if(conf.tryOne.getOrElse(false)) System.exit(0)
+        if(conf.tryOnce.getOrElse(false)) System.exit(0)
         TimeUnit.SECONDS.sleep(conf.cmdDelay.getOrElse(2))
       }
     }

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -1,0 +1,132 @@
+package org.renci.robocord
+
+import scala.sys.process._
+
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.exceptions.ScallopException
+import java.io.File
+
+import com.github.tototoshi.csv.CSVReader
+
+/**
+ * RoboCORD Manager manages runs of the RoboCORD Worker. Since we run RoboCORD on a SLURM-based cluster,
+ * we have a manager that starts workers using `srun` to fill in gaps that need executing.
+ */
+object RoboCORDManager extends App {
+  /**
+   * Command line configuration for RoboCORDManager.
+   */
+  class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+    override def onError(e: Throwable): Unit = e match {
+      case ScallopException(message) =>
+        printHelp
+        scribe.error(message)
+        System.exit(1)
+      case ex => super.onError(ex)
+    }
+
+    val version: String = getClass.getPackage.getImplementationVersion
+    version("RoboCORD: part of Omnicorp v" + version)
+
+    val metadata: ScallopOption[File] = opt[File](
+      descr = "The CSV file containing metadata",
+      default = Some(new File("robocord-data/metadata.csv"))
+    )
+    val outputDir: ScallopOption[File] = opt[File](
+      descr = "Directory containing output files. Our output files are in the format '$outputDir/result_from_{index}_until_{index}.txt'",
+      default = Some(new File("robocord-output"))
+    )
+    val neo4jLocation: ScallopOption[File] = opt[File](
+      descr = "Location of the Neo4J database that SciGraph should use.",
+      default = Some(new File("omnicorp-scigraph"))
+    )
+    val context: ScallopOption[Int] = opt[Int](
+      descr = "How many characters before and after the matched term should be displayed.",
+      default = Some(50)
+    )
+    val jobSize: ScallopOption[Int] = opt[Int](
+      descr = "The maximum number of rows in each job.",
+      default = Some(500)
+    )
+    val dryRun: ScallopOption[Boolean] = opt[Boolean](
+      descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
+      default = Some(false)
+    )
+
+    verify()
+  }
+
+  // Parse command line arguments.
+  val conf = new Conf(args)
+
+  // Load the metadata file.
+  val csvReader = CSVReader.open(conf.metadata())
+  val (headers: List[String], metadata: List[Map[String, String]]) = csvReader.allWithOrderedHeaders()
+  scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
+
+  // Get all existing output files.
+  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
+  val existingRangesSorted: Seq[Range] = conf.outputDir
+    .getOrElse(new File("robocord-output"))
+    .listFiles()
+    .toSeq
+    .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
+    .map(file => file.getName match {
+      case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
+      case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
+    })
+    .sortBy(_.start)
+
+  scribe.info(s"Ranges completed: ${existingRangesSorted}")
+
+  // We can now generate a set of ranges that work around those that have already been generated.
+  val rangesToProcess: Seq[Range] = if (existingRangesSorted.isEmpty) Seq(metadata.indices) else {
+    val rangesToExclude = (
+      new Range(metadata.indices.head, metadata.indices.head, 1)
+      +: existingRangesSorted :+
+      new Range(metadata.size, metadata.size, 1)
+    )
+    scribe.info(s"Ranges to exclude: ${rangesToExclude}")
+    scribe.info(s"Sliding ranges to exclude: ${rangesToExclude.sliding(2).toSeq}")
+    rangesToExclude
+      .sliding(2) // Group them up in pairs, i.e. indexes (0, 1), (1, 2), (2, 3), ...
+      .map({
+        // For each pair, choose the range from the end of the first range to the start of the next range
+        case Seq(prev, next) => Range(prev.end, next.start)
+      })
+      .filter(_.nonEmpty) // Some of these ranges may be empty (e.g. 640 to 640); we can exclude those.
+      .toSeq
+  }
+  scribe.info(s"Ranges to process: ${rangesToProcess.mkString(", ")}")
+
+  // Okay, now we know the ranges that need to be processed. We divide them up into jobs recursively.
+  var jobCount = 0
+  def processJob(range: Range): Unit = {
+    if (range.size > conf.jobSize.getOrElse(200)) {
+      val halfway: Int = range.start + range.size/2
+      processJob(new Range(range.start, halfway, 1))
+      processJob(new Range(halfway, range.end, 1))
+    } else {
+      jobCount += 1
+      val logger: ProcessLogger = ProcessLogger.apply(scribe.error(_))
+      if (conf.dryRun.getOrElse(true)) {
+        scribe.info(s" - Would execute job ${jobCount}: ${range} (size: ${range.size})")
+      } else {
+        val process = Seq(
+          "robocord-sbatch.sh",
+          "--metadata", "robocord-data/metadata.csv",
+          "--from-row", range.start.toString,
+          "--to-row", range.end.toString,
+          "--output-prefix", "robocord-output/results",
+          "robocord-data"
+        ).run(logger)
+        if (process.exitValue == 0)
+          scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size})")
+        else
+          scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
+      }
+    }
+  }
+
+  rangesToProcess.foreach(processJob(_))
+}

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -73,12 +73,12 @@ object RoboCORDManager extends App {
   scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
 
   // Get all existing output files.
-  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
+  val filenameRegex = """results_from_(\d+)_until_(\d+).txt""".r
   val existingRangesSorted: Seq[Range] = conf.outputDir
     .getOrElse(new File("robocord-output"))
     .listFiles()
     .toSeq
-    .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
+    .filter(file => file.getName.startsWith("results_") && file.getName.endsWith(".txt"))
     .map(file => file.getName match {
       case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
       case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
@@ -121,10 +121,11 @@ object RoboCORDManager extends App {
         scribe.info(s" - Would execute job ${jobCount}: ${range} (size: ${range.size})")
       } else {
         val cmd = Seq(
+	  "/bin/bash",
           "robocord-sbatch.sh",
           "--metadata", "robocord-data/metadata.csv",
           "--from-row", range.start.toString,
-          "--to-row", range.end.toString,
+          "--until-row", range.end.toString,
           "--output-prefix", "robocord-output/results",
           "robocord-data"
         )

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -121,7 +121,7 @@ object RoboCORDManager extends App {
         scribe.info(s" - Would execute job ${jobCount}: ${range} (size: ${range.size})")
       } else {
         val cmd = Seq(
-	  "/bin/bash",
+          "/bin/bash",
           "robocord-sbatch.sh",
           "--metadata", "robocord-data/metadata.csv",
           "--from-row", range.start.toString,

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -34,8 +34,7 @@ object OmnicorpTests extends TestSuite {
       val (status, stdout, stderr) = exec(Seq("sbt", "run"))
       assert(status == 1)
       assert(stdout contains "Omnicorp requires four arguments:")
-      assert(stdout contains "Nonzero exit code: 2")
-      assert(stderr contains "TrapExitSecurityException")
+      assert(stdout contains "Nonzero exit code returned from runner: 2")
     }
 
     test("On input file examplesForTests.xml") {
@@ -56,8 +55,8 @@ object OmnicorpTests extends TestSuite {
         assert(stdout contains "Total time:")
         assert(stdout contains "completed")
 
-        assert(stderr contains "Begin processing")
-        assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
+        assert(stdout contains "Begin processing")
+        assert(!finalResultRegex.findFirstIn(stdout).isEmpty)
       }
     }
 
@@ -79,12 +78,12 @@ object OmnicorpTests extends TestSuite {
         assert(stdout contains "Total time:")
         assert(stdout contains "completed")
 
-        assert(stderr contains "Begin processing")
-        assert(stderr contains "WARN org.renci.chemotext.PubMedTripleGenerator")
+        assert(stdout contains "Begin processing")
+        assert(stdout contains "WARN org.renci.chemotext.PubMedTripleGenerator")
         assert(
-          stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>"
+          stdout contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>"
         )
-        assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
+        assert(!finalResultRegex.findFirstIn(stdout).isEmpty)
       }
     }
   }


### PR DESCRIPTION
The previous approach -- splitting the input file into chunks -- made it difficult to identify which records had already been generated and which remained to be processed. This PR replaces that system with one based around specifying the rows that need to be processed on each run, but then providing tools so that these don't need to be specified by the operator. 

Specifically, this PR:
- Modifies RoboCORD.scala so that, rather than specifying the "chunk" ID, you specify which rows should be processed in that run.
- Writes output to an intermediate file (named `result_from_${startIndex}_until_${endIndex}.in-progress.txt`) before renaming it to a final output file (named `result_from_${startIndex}_until_${endIndex}.tsv`). This doesn't mean much right now, since I think we store everything in memory before writing it all out to disk, but once we replace processing with FS2 streams, this will actually be important.
- Modifies robocord.job so that an input job can be specified with the number of chunks to run (using the syntax `--array=0-[number of chunks]`), and then have it calculate which runs should be processed in each run.
- Adds a new program called RoboCORDManager that goes through the list of output files produced and confirms that every row in the metadata.csv file has been processed. If not, it can batch remaining rows into jobs and start them uses the `robocord-sbatch.sh` script, which itself uses `srun`.

These changes are documented in the README file.

Should be merged after #70.