### PR TITLE
Increased memory available to generate-tsv.job.

### DIFF
--- a/generate-tsv.job
+++ b/generate-tsv.job
@@ -4,13 +4,13 @@
 #SBATCH --output=tsv-output/log-output-%A.txt
 #SBATCH --error=tsv-output/log-error-%A.txt
 #SBATCH --cpus-per-task 32
-#SBATCH --mem=50000
+#SBATCH --mem=1000000
 #SBATCH --time=12:00:00
 #SBATCH --mail-user=gaurav@renci.org
 
 set -e # Exit immediately if a pipeline fails.
 
-export JAVA_OPTS="-Xmx50G"
+export JAVA_OPTS="-Xmx1000G"
 
 echo "Starting GenerateTSV, writing outputs to tsv-output/"
 sbt "runMain org.renci.chemotext.GenerateTSV"


### PR DESCRIPTION
Until we can replace generate-TSV with a stream-based solution (#65), we need all the memory we can use. This PR increases the memory requirement for running generate TSV to ~1000 GB.