### PR TITLE
Replace call to SciGraph's annotateEntities() with getAnnotations()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ robocord-test: SciGraph
 		ln -s robocord-outputs/${ROBOCORD_DATE} robocord-output; \
 	fi
 
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 640 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 768  robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 896  robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55936 --until-row 56064 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 140776 --until-row 141109 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 440 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 668  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 796  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55966 --until-row 56000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 150000 --until-row 160000 robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MEMORY = 16G
 PARALLEL = 4
 
 # The date of CORD-19 data to download.
-ROBOCORD_DATE="2020-06-02"
+ROBOCORD_DATE="2020-06-03"
 
 .PHONY: all
 all: output

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ robocord-test: SciGraph
 		ln -s robocord-outputs/${ROBOCORD_DATE} robocord-output; \
 	fi
 
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 4 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 5 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 6 --total-chunks 1000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk 437 --total-chunks 1000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 640 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 768  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 896  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55936 --until-row 56064 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 140776 --until-row 141109 robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: coursier output
 # RoboCORD
 .PHONY: robocord-download robocord-output robocord-test
 robocord-download:
-	# robocord-data is intended to be a symlink to robocord-datas/${ROBOCORD_DATE}, so that it is updated automatically. 
+	# robocord-data is intended to be a symlink to robocord-datas/${ROBOCORD_DATE}, so that it is updated automatically.
 	# If robocord-data doesn't exist or is a symlink, we update it
 	# automatically. Otherwise (i.e. if it's an existing directory),
 	# we only update the files already in it.
@@ -70,7 +70,7 @@ robocord-download:
 		mkdir -p robocord-datas/${ROBOCORD_DATE}; \
 		ln -s robocord-datas/${ROBOCORD_DATE} robocord-data; \
 	fi
-	
+
 	# Download CORD-19 into robocord-data.
 	wget -N "https://ai2-semanticscholar-cord-19.s3-us-west-2.amazonaws.com/historical_releases/cord-19_${ROBOCORD_DATE}.tar.gz" -P robocord-data
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,11 +43,16 @@ libraryDependencies ++= {
     "org.scala-lang.modules"      %% "scala-xml"              % "1.0.6",
     "io.scigraph"                 %  "scigraph-core"          % "2.1-SNAPSHOT",
     "io.scigraph"                 %  "scigraph-entity"        % "2.1-SNAPSHOT",
-    "com.typesafe.scala-logging"  %% "scala-logging"          % "3.7.1",
-    "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
     "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
+
+    // Testing
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test",
+
+    // Logging
+    "com.typesafe.scala-logging"  %% "scala-logging"          % "3.7.1",
+    "ch.qos.logback"              %  "logback-classic"        % "1.2.3",
+    "com.outr"                    %% "scribe"                 % "2.7.3",
 
     // Command line argument parsing.
     "org.rogach"                  %% "scallop"                % "3.3.2",

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ wartremoverWarnings ++= Warts.unsafe
 
 javaOptions += "-Xmx20G"
 
-fork in Test := true
+fork := true
 
 testFrameworks += new TestFramework("utest.runner.Framework")
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,8 @@ libraryDependencies ++= {
     "org.backuity.clist"          %% "clist-macros"           % "3.2.2" % "provided",
     "com.typesafe.akka"           %% "akka-stream"            % "2.5.9",
     "org.scala-lang.modules"      %% "scala-xml"              % "1.0.6",
-    "io.scigraph"                 %  "scigraph-core"          % "2.1-SNAPSHOT",
-    "io.scigraph"                 %  "scigraph-entity"        % "2.1-SNAPSHOT",
+    "io.scigraph"                 %  "scigraph-core"          % "2.2-SNAPSHOT",
+    "io.scigraph"                 %  "scigraph-entity"        % "2.2-SNAPSHOT",
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
     "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
 

--- a/robocord-sbatch.sh
+++ b/robocord-sbatch.sh
@@ -10,7 +10,7 @@ sbatch <<EOT
 #SBATCH --error=robocord-output/log-error-%A.txt
 #SBATCH --cpus-per-task 16
 #SBATCH --mem=50000
-#SBATCH --time=12:00:00
+#SBATCH --time=2:00:00
 #SBATCH --mail-user=gaurav@renci.org
 
 set -e # Exit immediately if a pipeline fails.

--- a/robocord-sbatch.sh
+++ b/robocord-sbatch.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# All arguments are passed on to the RoboCORD instance.
+
+sbatch <<EOT
+#!/bin/bash
+#
+#SBATCH --job-name=RoboCORD
+#SBATCH --output=robocord-output/log-output-%a.txt
+#SBATCH --error=robocord-output/log-error-%a.txt
+#SBATCH --cpus-per-task 16
+#SBATCH --mem=50000
+#SBATCH --time=12:00:00
+#SBATCH --mail-user=gaurav@renci.org
+
+set -e # Exit immediately if a pipeline fails.
+
+export JAVA_OPTS="-Xmx50G"
+export MY_SCIGRAPH=omnicorp-scigraph-\$SLURM_ARRAY_TASK_ID
+
+echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
+cp -R omnicorp-scigraph "scigraphs/\$MY_SCIGRAPH"
+
+echo "Starting RoboCORD with argumnets: $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
+sbt "runMain org.renci.robocord.RoboCORD $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
+
+rm -rf "scigraphs/\$MY_SCIGRAPH"
+echo "Deleted duplicated omnicorp-scigraph"
+EOT

--- a/robocord-sbatch.sh
+++ b/robocord-sbatch.sh
@@ -6,8 +6,8 @@ sbatch <<EOT
 #!/bin/bash
 #
 #SBATCH --job-name=RoboCORD
-#SBATCH --output=robocord-output/log-output-%a.txt
-#SBATCH --error=robocord-output/log-error-%a.txt
+#SBATCH --output=robocord-output/log-output-%A.txt
+#SBATCH --error=robocord-output/log-error-%A.txt
 #SBATCH --cpus-per-task 16
 #SBATCH --mem=50000
 #SBATCH --time=12:00:00
@@ -16,13 +16,13 @@ sbatch <<EOT
 set -e # Exit immediately if a pipeline fails.
 
 export JAVA_OPTS="-Xmx50G"
-export MY_SCIGRAPH=omnicorp-scigraph-\$SLURM_ARRAY_TASK_ID
+export MY_SCIGRAPH=omnicorp-scigraph-\$SLURM_JOB_ID
 
 echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
 cp -R omnicorp-scigraph "scigraphs/\$MY_SCIGRAPH"
 
-echo "Starting RoboCORD with argumnets: $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
-sbt "runMain org.renci.robocord.RoboCORD $@ --neo4j-location scigraphs/\$MY_SCIGRAPH"
+echo "Starting RoboCORD with arguments: --neo4j-location scigraphs/\$MY_SCIGRAPH $@"
+sbt "runMain org.renci.robocord.RoboCORD --neo4j-location scigraphs/\$MY_SCIGRAPH $@"
 
 rm -rf "scigraphs/\$MY_SCIGRAPH"
 echo "Deleted duplicated omnicorp-scigraph"

--- a/robocord.job
+++ b/robocord.job
@@ -26,7 +26,7 @@ else
     cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
 
     echo "Starting RoboCORD from row $FROM_ROW until $UNTIL_ROW."
-    sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row $FROM_ROW --until-row $UNTIL_ROW --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+    sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row $FROM_ROW --until-row $UNTIL_ROW --output-prefix robocord-output/result --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
 
     rm -rf "scigraphs/$MY_SCIGRAPH"
     echo "Deleted duplicated omnicorp-scigraph"

--- a/robocord.job
+++ b/robocord.job
@@ -5,7 +5,7 @@
 #SBATCH --error=robocord-output/log-error-%a.txt
 #SBATCH --cpus-per-task 16
 #SBATCH --mem=50000
-#SBATCH --time=12:00:00
+#SBATCH --time=4:00:00
 #SBATCH --mail-user=gaurav@renci.org
 
 set -e # Exit immediately if a pipeline fails.
@@ -13,11 +13,21 @@ set -e # Exit immediately if a pipeline fails.
 export JAVA_OPTS="-Xmx50G"
 export MY_SCIGRAPH=omnicorp-scigraph-$SLURM_ARRAY_TASK_ID
 
-echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
-cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
+export METADATA_SIZE=$(($(wc -l < robocord-data/metadata.csv) - 1))
+export CHUNK_SIZE=$(($METADATA_SIZE/$SLURM_ARRAY_TASK_MAX))
+export FROM_ROW=$(($SLURM_ARRAY_TASK_ID * $CHUNK_SIZE))
+export UNTIL_ROW=$(($FROM_ROW + $CHUNK_SIZE))
+export OUTPUT_FILENAME=robocord-output/result_from_${FROM_ROW}_until_${UNTIL_ROW}.tsv
 
-echo "Starting RoboCORD"
-sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --current-chunk $SLURM_ARRAY_TASK_ID --total-chunks $SLURM_ARRAY_TASK_MAX --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+if [ -f $OUTPUT_FILENAME ]; then
+    echo Output filename $OUTPUT_FILENAME already exists, skipping.
+else
+    echo "Duplicating omnicorp-scigraph so we can use it on multiple clusters"
+    cp -R omnicorp-scigraph "scigraphs/$MY_SCIGRAPH"
 
-rm -rf "scigraphs/$MY_SCIGRAPH"
-echo "Deleted duplicated omnicorp-scigraph"
+    echo "Starting RoboCORD from row $FROM_ROW until $UNTIL_ROW."
+    sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row $FROM_ROW --until-row $UNTIL_ROW --output-prefix robocord-output/results --neo4j-location scigraphs/$MY_SCIGRAPH robocord-data"
+
+    rm -rf "scigraphs/$MY_SCIGRAPH"
+    echo "Deleted duplicated omnicorp-scigraph"
+fi

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -102,7 +102,7 @@ object RoboCORD extends App with LazyLogging {
   val endIndex: Int = startIndex + chunkLength
 
   // Do we already have an output file? If so, we abort.
-  val inProgressFilename = "in-progress." + conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
+  val inProgressFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.in-progress.txt"
   if (new File(inProgressFilename).exists()) {
     if (new File(inProgressFilename).delete())
       logger.info(s"In-progress output file '${inProgressFilename}' already exists and has been deleted.")

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -35,7 +35,7 @@ object RoboCORD extends App with LazyLogging {
       default = Some(new File("robocord-data/all_sources_metadata_latest.csv"))
     )
     val outputPrefix: ScallopOption[String] = opt[String](
-      descr = "Prefix for the filename (we will add '_from_<start index>_until_<end index>.txt' to the filename)",
+      descr = "Prefix for the filename (we will add '_from_<start index>_until_<end index>.tsv' to the filename)",
       default = Some("robocord-output/result")
     )
     val neo4jLocation: ScallopOption[File] = opt[File](
@@ -109,7 +109,7 @@ object RoboCORD extends App with LazyLogging {
     }
   }
 
-  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
+  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.tsv"
   if (new File(outputFilename).length > 0) {
     logger.info(s"Output file '${outputFilename}' already exists, skipping.")
     System.exit(0)

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -67,8 +67,30 @@ object RoboCORD extends App with LazyLogging {
 
   // Load the metadata file.
   val csvReader = CSVReader.open(conf.metadata())
-  val allMetadata: List[Map[String, String]] = csvReader.allWithHeaders()
+  val (headers: List[String], allMetadata: List[Map[String, String]]) = csvReader.allWithOrderedHeaders()
   logger.info(s"Loaded ${allMetadata.size} articles from metadata file ${conf.metadata()}.")
+
+  // Let's make sure the loaded metadata is what we expect -- if not, fields might have changed unexpectedly!
+  assert(headers == List(
+    "cord_uid",
+    "sha",
+    "source_x",
+    "title",
+    "doi",
+    "pmcid",
+    "pubmed_id",
+    "license",
+    "abstract",
+    "publish_time",
+    "authors",
+    "journal",
+    "mag_id",
+    "who_covidence_id",
+    "arxiv_id",
+    "pdf_json_files",
+    "pmc_json_files",
+    "url"
+  ))
 
   // Which metadata entries do we actually need to process?
   val currentChunk: Int = conf.currentChunk()

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -89,7 +89,8 @@ object RoboCORD extends App with LazyLogging {
     "arxiv_id",
     "pdf_json_files",
     "pmc_json_files",
-    "url"
+    "url",
+    "s2_id"
   ))
 
   // Which metadata entries do we actually need to process?

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -104,37 +104,21 @@ object RoboCORD extends App with LazyLogging {
   val articlesTotal = metadata.size
   logger.info(s"Selected $articlesTotal articles for processing (from $startIndex until $endIndex, chunk $currentChunk out of $totalChunks)")
 
-  // Identify full text SHAs and PMCIDs in the current chunk (`metadata`).
-  val shasToLoad = metadata.flatMap(_.get("sha")).flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
-  val pmcIdsToLoad = metadata.flatMap(_.get("pmcid")).flatMap(_.split(';')).map(_.trim.toLowerCase).toSet
-  // logger.info(s"shasToLoad: $shasToLoad")
-  // logger.info(s"pmcIdsToLoad: $pmcIdsToLoad")
-
-  // Load up full text data for those SHAs and PMCIDs, and create a map so we can identify them easily.
-  val fullTextData: Seq[CORDArticleWrapper] = conf.data().flatMap(CORDJsonReader.wrapFileOrDir(_, logger, shasToLoad, pmcIdsToLoad))
-  val fullTextById: Map[String, Seq[CORDArticleWrapper]] = fullTextData.groupBy(_.id)
-  logger.info(s"Loaded ${fullTextData.size} full text documents corresponding to ${fullTextById.keySet.size} IDs.")
-
   // Run SciGraph in parallel over the chunk we need to process.
   logger.info(s"Starting SciGraph in parallel on ${Runtime.getRuntime.availableProcessors} processors.")
 
   var articlesCompleted = 0
 
   // Summarize all files into the output directory.
-  val results: ParSeq[String] = metadata.par.flatMap(entry => {
+  val results: ParSeq[String] = metadata.zipWithIndex.par.flatMap({ case (entry, index) =>
     // Find the ID of this article.
-    val id = entry("cord_uid")
+    // We have some duplicate CORD_UIDs (yes, really!). So we add the metadata row index to make it fully unique.
+    val id = s"${entry("cord_uid")}:${startIndex + index}"
     val pmid = entry.get("pubmed_id")
     val doi = entry.get("doi")
 
-    // For SHA and PMCID, we do a little additional processing: if there are multiple SHAs or PMCIDs,
-    // we only use the last one, but we record all IDs in the log.
-    val shas = entry.getOrElse("sha", "").split(';').map(_.trim).filter(_.nonEmpty)
-    val sha = if (shas.length > 1) {
-      val shaLast = shas.last
-      logger.info(s"Found multiple SHAs for $id, choosing the last one ($shaLast) out of: $shas")
-      shaLast
-    } else shas.headOption.getOrElse("")
+    // It looks like there are no articules with multiple duplicate PMCIDs, but let's be paranoid
+    // and use only the last one.
     val pmcids = entry.getOrElse("pmcid", "").split(';').map(_.trim).filter(_.nonEmpty)
     val pmcid = if (pmcids.length > 1) {
       val pmcidLast = pmcids.last
@@ -148,20 +132,28 @@ object RoboCORD extends App with LazyLogging {
       else if(pmcid.nonEmpty) pmcid.map("PMCID:" + _)
       else s"CORD_UID:$id"
 
-    // Determine which full text document to use. If a full text JSON document (via SHA or PMCID) is available,
-    // we use that. Otherwise, we fall back to the title and abstract from the metadata file.
-    val (fullText, withFullText) = if (pmcid.nonEmpty && fullTextById.contains(pmcid)) {
-      // Retrieve the full text.
-      (
-        fullTextById.getOrElse(pmcid, Seq.empty).map(_.fullText).mkString("\n===\n"),
-        s"with full text from PMCID $pmcid"
-      )
-    } else if (sha.nonEmpty && fullTextById.contains(sha)) {
-      // Retrieve the full text.
-      (
-        fullTextById.getOrElse(sha, Seq.empty).map(_.fullText).mkString("\n===\n"),
-        s"with full text from SHA $sha"
-      )
+    // Full-text articles are stored by path. We might have multiple PMC or PDF parses; we prioritize PMC over PDF.
+    val pmcJSONFiles = entry("pmc_json_files").split(';').map(_.trim).filter(_.nonEmpty)
+    val pdfJSONFiles = entry("pdf_json_files").split(';').map(_.trim).filter(_.nonEmpty)
+    val fullTextFilename: String = if (pmcJSONFiles.nonEmpty) {
+      if (pmcJSONFiles.length == 1) pmcJSONFiles.head
+      else {
+        val pmcLast = pmcJSONFiles.last
+        logger.info(s"Found multiple PMC JSON files, choosing the last one ($pmcLast) out of $pmcJSONFiles")
+        pmcLast
+      }
+    } else if (pdfJSONFiles.nonEmpty) {
+      if (pdfJSONFiles.length == 1) pdfJSONFiles.head
+      else {
+        val pdfLast = pdfJSONFiles.last
+        logger.info(s"Found multiple PDF JSON files, choosing the last one ($pdfLast) out of $pdfJSONFiles")
+        pdfLast
+      }
+    } else ""
+
+    val (fullText, withFullText) = if (fullTextFilename.nonEmpty) {
+      val jsonReader = CORDJsonReader.wrapFile(new File(fullTextFilename), logger)
+      (jsonReader.map(_.fullText).mkString("\n===\n"), s"with full text from $fullTextFilename")
     } else {
       // We don't have full text, so just annotate the title and abstract.
       val title: String = entry.getOrElse("title", "")

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -152,7 +152,7 @@ object RoboCORD extends App with LazyLogging {
     } else ""
 
     val (fullText, withFullText) = if (fullTextFilename.nonEmpty) {
-      val jsonReader = CORDJsonReader.wrapFile(new File(fullTextFilename), logger)
+      val jsonReader = CORDJsonReader.wrapFile(new File(new File("robocord-data"), fullTextFilename), logger)
       (jsonReader.map(_.fullText).mkString("\n===\n"), s"with full text from $fullTextFilename")
     } else {
       // We don't have full text, so just annotate the title and abstract.

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -100,6 +100,13 @@ object RoboCORD extends App with LazyLogging {
   val startIndex: Int = currentChunk * chunkLength
   val endIndex: Int = startIndex + chunkLength
 
+  // Do we already have an output file? If so, we abort.
+  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
+  if (new File(outputFilename).length > 0) {
+    logger.info(s"Output file '${outputFilename}' already exists, skipping.")
+    System.exit(0);
+  }
+
   // Divide allMetadata into chunks based on totalChunks.
   val metadata: Seq[Map[String, String]] = allMetadata.slice(startIndex, endIndex)
   val articlesTotal = metadata.size
@@ -181,7 +188,6 @@ object RoboCORD extends App with LazyLogging {
   })
 
   // Write out all the results to the output file.
-  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.txt"
   logger.info(s"Writing tab-delimited output to $outputFilename.")
   val pw = new PrintWriter(new FileWriter(new File(outputFilename)))
   results.foreach(pw.println(_))

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -145,7 +145,7 @@ object RoboCORD extends App with LazyLogging {
     // Choose an "article ID", which is one of: (1) PubMed ID, (2) DOI, (3) PMCID or (4) CORD_UID.
     val articleId = if (pmid.nonEmpty && pmid.get.nonEmpty) pmid.map("PMID:" + _).mkString("|")
       else if(doi.nonEmpty && doi.get.nonEmpty) doi.map("DOI:" + _).mkString("|")
-      else if(pmcid.nonEmpty) pmcid.map("PMCID:" + _)
+      else if(pmcid.nonEmpty) s"PMCID:${pmcid}"
       else s"CORD_UID:$id"
 
     // Full-text articles are stored by path. We might have multiple PMC or PDF parses; we prioritize PMC over PDF.

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -107,6 +107,14 @@ object RoboCORDManager extends App {
   }
   scribe.info(s"Ranges to process: ${rangesToProcess.mkString(", ")}")
 
+  // Generate warnings for overlapping output files.
+  val existingRanges = existingRangesSorted.toSet
+  existingRanges.foreach(range => {
+    existingRanges.filter(r => r != range && r.intersect(range).nonEmpty).foreach(r => {
+      scribe.warn(s"Output files are present for both ${range} and ${r}")
+    })
+  })
+
   // Okay, now we know the ranges that need to be processed. We divide them up into jobs recursively.
   var jobCount = 0
   def processJob(range: Range): Unit = {

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -115,6 +115,10 @@ object RoboCORDManager extends App {
     })
   })
 
+  if (rangesToProcess.isEmpty) {
+    scribe.info("No ranges remain to be processed. No jobs need to be created.")
+  }
+
   // Okay, now we know the ranges that need to be processed. We divide them up into jobs recursively.
   var jobCount = 0
   def processJob(range: Range): Unit = {

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -73,12 +73,12 @@ object RoboCORDManager extends App {
   scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
 
   // Get all existing output files.
-  val filenameRegex = """results_from_(\d+)_until_(\d+).txt""".r
+  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
   val existingRangesSorted: Seq[Range] = conf.outputDir
     .getOrElse(new File("robocord-output"))
     .listFiles()
     .toSeq
-    .filter(file => file.getName.startsWith("results_") && file.getName.endsWith(".txt"))
+    .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
     .map(file => file.getName match {
       case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
       case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
@@ -138,7 +138,7 @@ object RoboCORDManager extends App {
           "--metadata", "robocord-data/metadata.csv",
           "--from-row", range.start.toString,
           "--until-row", range.end.toString,
-          "--output-prefix", "robocord-output/results",
+          "--output-prefix", "robocord-output/result",
           "robocord-data"
         )
         val process = cmd.run(logger)

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -52,7 +52,7 @@ object RoboCORDManager extends App {
       descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
       default = Some(false)
     )
-    val tryOnce: ScallopOption[Boolean] = opt[Boolean](
+    val tryOne: ScallopOption[Boolean] = opt[Boolean](
       descr = "If true, try executing a single job.",
       default = Some(false)
     )
@@ -146,7 +146,7 @@ object RoboCORDManager extends App {
           scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size}): ${cmd}")
         else
           scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
-        if(conf.tryOnce.getOrElse(false)) System.exit(0)
+        if(conf.tryOne.getOrElse(false)) System.exit(0)
         TimeUnit.SECONDS.sleep(conf.cmdDelay.getOrElse(2))
       }
     }

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -52,7 +52,7 @@ object RoboCORDManager extends App {
       descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
       default = Some(false)
     )
-    val tryOne: ScallopOption[Boolean] = opt[Boolean](
+    val tryOnce: ScallopOption[Boolean] = opt[Boolean](
       descr = "If true, try executing a single job.",
       default = Some(false)
     )
@@ -134,7 +134,7 @@ object RoboCORDManager extends App {
           scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size}): ${cmd}")
         else
           scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
-        if(conf.tryOne.getOrElse(false)) System.exit(0)
+        if(conf.tryOnce.getOrElse(false)) System.exit(0)
         TimeUnit.SECONDS.sleep(conf.cmdDelay.getOrElse(2))
       }
     }

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -1,0 +1,132 @@
+package org.renci.robocord
+
+import scala.sys.process._
+
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.exceptions.ScallopException
+import java.io.File
+
+import com.github.tototoshi.csv.CSVReader
+
+/**
+ * RoboCORD Manager manages runs of the RoboCORD Worker. Since we run RoboCORD on a SLURM-based cluster,
+ * we have a manager that starts workers using `srun` to fill in gaps that need executing.
+ */
+object RoboCORDManager extends App {
+  /**
+   * Command line configuration for RoboCORDManager.
+   */
+  class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+    override def onError(e: Throwable): Unit = e match {
+      case ScallopException(message) =>
+        printHelp
+        scribe.error(message)
+        System.exit(1)
+      case ex => super.onError(ex)
+    }
+
+    val version: String = getClass.getPackage.getImplementationVersion
+    version("RoboCORD: part of Omnicorp v" + version)
+
+    val metadata: ScallopOption[File] = opt[File](
+      descr = "The CSV file containing metadata",
+      default = Some(new File("robocord-data/metadata.csv"))
+    )
+    val outputDir: ScallopOption[File] = opt[File](
+      descr = "Directory containing output files. Our output files are in the format '$outputDir/result_from_{index}_until_{index}.txt'",
+      default = Some(new File("robocord-output"))
+    )
+    val neo4jLocation: ScallopOption[File] = opt[File](
+      descr = "Location of the Neo4J database that SciGraph should use.",
+      default = Some(new File("omnicorp-scigraph"))
+    )
+    val context: ScallopOption[Int] = opt[Int](
+      descr = "How many characters before and after the matched term should be displayed.",
+      default = Some(50)
+    )
+    val jobSize: ScallopOption[Int] = opt[Int](
+      descr = "The maximum number of rows in each job.",
+      default = Some(500)
+    )
+    val dryRun: ScallopOption[Boolean] = opt[Boolean](
+      descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
+      default = Some(false)
+    )
+
+    verify()
+  }
+
+  // Parse command line arguments.
+  val conf = new Conf(args)
+
+  // Load the metadata file.
+  val csvReader = CSVReader.open(conf.metadata())
+  val (headers: List[String], metadata: List[Map[String, String]]) = csvReader.allWithOrderedHeaders()
+  scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
+
+  // Get all existing output files.
+  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
+  val existingRangesSorted: Seq[Range] = conf.outputDir
+    .getOrElse(new File("robocord-output"))
+    .listFiles()
+    .toSeq
+    .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
+    .map(file => file.getName match {
+      case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
+      case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
+    })
+    .sortBy(_.start)
+
+  scribe.info(s"Ranges completed: ${existingRangesSorted}")
+
+  // We can now generate a set of ranges that work around those that have already been generated.
+  val rangesToProcess: Seq[Range] = if (existingRangesSorted.isEmpty) Seq(metadata.indices) else {
+    val rangesToExclude = (
+      new Range(metadata.indices.head, metadata.indices.head, 1)
+      +: existingRangesSorted :+
+      new Range(metadata.size, metadata.size, 1)
+    )
+    scribe.info(s"Ranges to exclude: ${rangesToExclude}")
+    scribe.info(s"Sliding ranges to exclude: ${rangesToExclude.sliding(2).toSeq}")
+    rangesToExclude
+      .sliding(2) // Group them up in pairs, i.e. indexes (0, 1), (1, 2), (2, 3), ...
+      .map({
+        // For each pair, choose the range from the end of the first range to the start of the next range
+        case Seq(prev, next) => Range(prev.end, next.start)
+      })
+      .filter(_.nonEmpty) // Some of these ranges may be empty (e.g. 640 to 640); we can exclude those.
+      .toSeq
+  }
+  scribe.info(s"Ranges to process: ${rangesToProcess.mkString(", ")}")
+
+  // Okay, now we know the ranges that need to be processed. We divide them up into jobs recursively.
+  var jobCount = 0
+  def processJob(range: Range): Unit = {
+    if (range.size > conf.jobSize.getOrElse(200)) {
+      val halfway: Int = range.start + range.size/2
+      processJob(new Range(range.start, halfway, 1))
+      processJob(new Range(halfway, range.end, 1))
+    } else {
+      jobCount += 1
+      val logger: ProcessLogger = ProcessLogger.apply(scribe.error(_))
+      if (conf.dryRun.getOrElse(true)) {
+        scribe.info(s" - Would execute job ${jobCount}: ${range} (size: ${range.size})")
+      } else {
+        val process = Seq(
+          "robocord-sbatch.sh",
+          "--metadata", "robocord-data/metadata.csv",
+          "--from-row", range.start.toString,
+          "--to-row", range.end.toString,
+          "--output-prefix", "robocord-output/results",
+          "robocord-data"
+        ).run(logger)
+        if (process.exitValue == 0)
+          scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size})")
+        else
+          scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
+      }
+    }
+  }
+
+  rangesToProcess.foreach(processJob(_))
+}

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -73,12 +73,12 @@ object RoboCORDManager extends App {
   scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
 
   // Get all existing output files.
-  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
+  val filenameRegex = """results_from_(\d+)_until_(\d+).txt""".r
   val existingRangesSorted: Seq[Range] = conf.outputDir
     .getOrElse(new File("robocord-output"))
     .listFiles()
     .toSeq
-    .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
+    .filter(file => file.getName.startsWith("results_") && file.getName.endsWith(".txt"))
     .map(file => file.getName match {
       case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
       case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
@@ -121,10 +121,11 @@ object RoboCORDManager extends App {
         scribe.info(s" - Would execute job ${jobCount}: ${range} (size: ${range.size})")
       } else {
         val cmd = Seq(
+	  "/bin/bash",
           "robocord-sbatch.sh",
           "--metadata", "robocord-data/metadata.csv",
           "--from-row", range.start.toString,
-          "--to-row", range.end.toString,
+          "--until-row", range.end.toString,
           "--output-prefix", "robocord-output/results",
           "robocord-data"
         )

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -121,7 +121,7 @@ object RoboCORDManager extends App {
         scribe.info(s" - Would execute job ${jobCount}: ${range} (size: ${range.size})")
       } else {
         val cmd = Seq(
-	  "/bin/bash",
+          "/bin/bash",
           "robocord-sbatch.sh",
           "--metadata", "robocord-data/metadata.csv",
           "--from-row", range.start.toString,

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -29,6 +29,10 @@ class Annotator(neo4jLocation: File) extends LazyLogging {
   /** Extract annotations from a particular string using SciGraph. */
   def extractAnnotations(str: String): (String, List[EntityAnnotation]) = {
     val parsedString = QueryParserBase.escape(str)
+    // parsedString may contain HTML tags, which mess up indexes.
+    // We eliminate them here.
+      .replace("<", "_lt_")
+      .replace(">", "_gt_")
     val configBuilder = new EntityFormatConfiguration.Builder(new StringReader(parsedString))
         .longestOnly(true)
         .minLength(3)

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -29,13 +29,10 @@ class Annotator(neo4jLocation: File) extends LazyLogging {
   /** Extract annotations from a particular string using SciGraph. */
   def extractAnnotations(str: String): (String, List[EntityAnnotation]) = {
     val parsedString = QueryParserBase.escape(str)
-    // parsedString may contain HTML tags, which mess up indexes.
-    // We eliminate them here.
-      .replace("<", "_lt_")
-      .replace(">", "_gt_")
+      // .replace("*", "\\*")  // Not sure why these don't get escaped, but here we go.
     val configBuilder = new EntityFormatConfiguration.Builder(new StringReader(parsedString))
         .longestOnly(true)
         .minLength(3)
-    (parsedString, processor.annotateEntities(configBuilder.get).asScala.toList)
+    (parsedString, processor.getAnnotations(parsedString, configBuilder.get).asScala.toList)
   }
 }

--- a/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
+++ b/src/test/scala/org/renci/chemotext/OmnicorpTests.scala
@@ -34,8 +34,7 @@ object OmnicorpTests extends TestSuite {
       val (status, stdout, stderr) = exec(Seq("sbt", "run"))
       assert(status == 1)
       assert(stdout contains "Omnicorp requires four arguments:")
-      assert(stdout contains "Nonzero exit code: 2")
-      assert(stderr contains "TrapExitSecurityException")
+      assert(stdout contains "Nonzero exit code returned from runner: 2")
     }
 
     test("On input file examplesForTests.xml") {
@@ -56,8 +55,8 @@ object OmnicorpTests extends TestSuite {
         assert(stdout contains "Total time:")
         assert(stdout contains "completed")
 
-        assert(stderr contains "Begin processing")
-        assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
+        assert(stdout contains "Begin processing")
+        assert(!finalResultRegex.findFirstIn(stdout).isEmpty)
       }
     }
 
@@ -79,12 +78,12 @@ object OmnicorpTests extends TestSuite {
         assert(stdout contains "Total time:")
         assert(stdout contains "completed")
 
-        assert(stderr contains "Begin processing")
-        assert(stderr contains "WARN org.renci.chemotext.PubMedTripleGenerator")
+        assert(stdout contains "Begin processing")
+        assert(stdout contains "WARN org.renci.chemotext.PubMedTripleGenerator")
         assert(
-          stderr contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>"
+          stdout contains "Unable to parse date http://purl.org/dc/terms/issued on https://www.ncbi.nlm.nih.gov/pubmed/10542500: Could not parse XML node as date: <PubDate><MedlineDate>Dec-Jan</MedlineDate></PubDate>"
         )
-        assert(!finalResultRegex.findFirstIn(stderr).isEmpty)
+        assert(!finalResultRegex.findFirstIn(stdout).isEmpty)
       }
     }
   }


### PR DESCRIPTION
SciGraph's `annotateEntities()` has some problems that result in incorrect indexes in the output data (https://github.com/SciGraph/SciGraph/issues/282). This PR replaces that call with a call to the protected method `getAnnotations()` instead, which can work on plain text and returns accurate indexes.

This code will only work if the SciGraph has `getAnnotations()` made public, such as e.g. in the PR https://github.com/SciGraph/SciGraph/pull/283. 