### PR TITLE
Replace Scala parallel collections with FS2 streams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MEMORY = 16G
 PARALLEL = 4
 
 # The date of CORD-19 data to download.
-ROBOCORD_DATE="2020-08-30"
+ROBOCORD_DATE="2020-09-02"
 .PHONY: all
 all: output
 

--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,4 @@ robocord-test: SciGraph
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 668  robocord-data"
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 796  robocord-data"
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55966 --until-row 56000 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 150000 --until-row 160000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 15000000 --until-row 16000000 robocord-data"

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ robocord-test: SciGraph
 		ln -s robocord-outputs/${ROBOCORD_DATE} robocord-output; \
 	fi
 
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 640 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 768  robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 896  robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55936 --until-row 56064 robocord-data"
-	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 140776 --until-row 141109 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 440 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 668  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 796  robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 55966 --until-row 56000 robocord-data"
+	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 150000 --until-row 160000 robocord-data"

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,11 @@ libraryDependencies ++= {
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
     "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
 
+    // fs2 streams
+    "co.fs2"                      %% "fs2-core"               % "2.4.4", // For cats 2 and cats-effect 2
+    "co.fs2"                      %% "fs2-io"                 % "2.4.4",
+    "co.fs2"                      %% "fs2-reactive-streams"   % "2.4.4",
+
     // Testing
     "com.lihaoyi"                 %% "utest"                  % "0.7.1" % "test",
 

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -206,7 +206,7 @@ object RoboCORD extends IOApp with LazyLogging {
 
     // Step 2. Annotate full texts, and concatenate annotations with metadata to produce final output.
     val annotationStream: Stream[IO, String] = preAnnotationStream
-      .debug(metadata => s"Processing ${metadata._1}")
+      .debug(metadata => s"Searching for annotations in ${metadata._1}")
       .flatMap({
         case (metadataString, fullText) =>
           // Extract annotations from the full text using SciGraph.

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -1,17 +1,17 @@
 package org.renci.robocord
 
-import java.io.{File, FileWriter, PrintWriter}
-import java.nio.file.{CopyOption, Files, StandardCopyOption}
+import java.io.File
+import java.nio.file.{Files, StandardCopyOption}
 import java.time.Duration
 
+import cats.effect.{Blocker, ContextShift, ExitCode, IO}
 import com.github.tototoshi.csv._
 import com.typesafe.scalalogging.{LazyLogging, Logger}
+import fs2.{Stream, io, text}
 import org.renci.robocord.annotator.Annotator
 import org.renci.robocord.json.CORDJsonReader
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions._
-
-import scala.collection.parallel.ParSeq
 
 object RoboCORD extends App with LazyLogging {
   /**
@@ -58,156 +58,198 @@ object RoboCORD extends App with LazyLogging {
     verify()
   }
 
-  val timeStarted = System.nanoTime
+  def run(args: List[String]): IO[ExitCode] = {
+    val timeStarted = System.nanoTime
 
-  // Parse command line arguments.
-  val conf = new Conf(args, logger)
+    // Parse command line arguments.
+    val conf = new Conf(args, logger)
 
-  // Set up Annotator.
-  val annotator: Annotator = new Annotator(conf.neo4jLocation())
-
-  // Load the metadata file.
-  val csvReader = CSVReader.open(conf.metadata())
-  val (headers: List[String], allMetadata: List[Map[String, String]]) = csvReader.allWithOrderedHeaders()
-  logger.info(s"Loaded ${allMetadata.size} articles from metadata file ${conf.metadata()}.")
-
-  // Let's make sure the loaded metadata is what we expect -- if not, fields might have changed unexpectedly!
-  assert(headers == List(
-    "cord_uid",
-    "sha",
-    "source_x",
-    "title",
-    "doi",
-    "pmcid",
-    "pubmed_id",
-    "license",
-    "abstract",
-    "publish_time",
-    "authors",
-    "journal",
-    "mag_id",
-    "who_covidence_id",
-    "arxiv_id",
-    "pdf_json_files",
-    "pmc_json_files",
-    "url",
-    "s2_id"
-  ))
-
-  // Which metadata entries do we actually need to process?
-  val startIndex = conf.fromRow.toOption.get
-  val endIndex = conf.untilRow.toOption.get
-
-  // Do we already have an output file? If so, we abort.
-  val inProgressFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.in-progress.txt"
-  if (new File(inProgressFilename).exists()) {
-    if (new File(inProgressFilename).delete())
-      logger.info(s"In-progress output file '${inProgressFilename}' already exists and has been deleted.")
-    else {
-      logger.info(s"In-progress output file '${inProgressFilename}' already exists but could not be deleted.")
-      System.exit(2)
-    }
-  }
-
-  val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.tsv"
-  if (new File(outputFilename).length > 0) {
-    logger.info(s"Output file '${outputFilename}' already exists, skipping.")
-    System.exit(0)
-  }
-
-  // Divide allMetadata into chunks based on totalChunks.
-  val metadata: Seq[Map[String, String]] = allMetadata.slice(startIndex, endIndex)
-  val articlesTotal = metadata.size
-  logger.info(s"Selected $articlesTotal articles for processing (from $startIndex until $endIndex)")
-
-  // Run SciGraph in parallel over the chunk we need to process.
-  logger.info(s"Starting SciGraph in parallel on ${Runtime.getRuntime.availableProcessors} processors.")
-
-  var articlesCompleted = 0
-
-  // Summarize all files into the output directory.
-  val results: ParSeq[String] = metadata.zipWithIndex.par.flatMap({ case (entry, index) =>
-    // Find the ID of this article.
-    // We have some duplicate CORD_UIDs (yes, really!). So we add the metadata row index to make it fully unique.
-    val id = s"${entry("cord_uid")}:${startIndex + index}"
-    val pmid = entry.get("pubmed_id")
-    val doi = entry.get("doi")
-
-    // It looks like there are no articles with multiple duplicate PMCIDs, but let's be paranoid
-    // and use only the last one.
-    val pmcids = entry.getOrElse("pmcid", "").split(';').map(_.trim).filter(_.nonEmpty)
-    val pmcid = if (pmcids.length > 1) {
-      val pmcidLast = pmcids.last
-      logger.info(s"Found multiple PMCIDs for $id, choosing the last one ($pmcidLast) out of: $pmcids")
-      pmcidLast
-    } else pmcids.headOption.getOrElse("")
-
-    // Choose an "article ID", which is one of: (1) PubMed ID, (2) DOI, (3) PMCID or (4) CORD_UID.
-    val articleId = if (pmid.nonEmpty && pmid.get.nonEmpty) pmid.map("PMID:" + _).mkString("|")
-      else if(doi.nonEmpty && doi.get.nonEmpty) doi.map("DOI:" + _).mkString("|")
-      else if(pmcid.nonEmpty) s"PMCID:${pmcid}"
-      else s"CORD_UID:$id"
-
-    // Full-text articles are stored by path. We might have multiple PMC or PDF parses; we prioritize PMC over PDF.
-    val pmcJSONFiles = entry("pmc_json_files").split(';').map(_.trim).filter(_.nonEmpty)
-    val pdfJSONFiles = entry("pdf_json_files").split(';').map(_.trim).filter(_.nonEmpty)
-    val fullTextFilename: String = if (pmcJSONFiles.nonEmpty) {
-      if (pmcJSONFiles.length == 1) pmcJSONFiles.head
-      else {
-        val pmcLast = pmcJSONFiles.last
-        logger.info(s"Found multiple PMC JSON files, choosing the last one ($pmcLast) out of $pmcJSONFiles")
-        pmcLast
-      }
-    } else if (pdfJSONFiles.nonEmpty) {
-      if (pdfJSONFiles.length == 1) pdfJSONFiles.head
-      else {
-        val pdfLast = pdfJSONFiles.last
-        logger.info(s"Found multiple PDF JSON files, choosing the last one ($pdfLast) out of $pdfJSONFiles")
-        pdfLast
-      }
-    } else ""
-
-    val (fullText, withFullText) = if (fullTextFilename.nonEmpty) {
-      val jsonReader = CORDJsonReader.wrapFile(new File(new File("robocord-data"), fullTextFilename), logger)
-      (jsonReader.map(_.fullText).mkString("\n===\n"), s"with full text from $fullTextFilename")
-    } else {
-      // We don't have full text, so just annotate the title and abstract.
-      val title: String = entry.getOrElse("title", "")
-      val abstractText = entry.getOrElse("abstract", "")
-      (
-        s"$title\n$abstractText",
-        "without full text"
+    processEntries(conf).compile.drain.redeem(err => {
+      val duration = Duration.ofNanos(System.nanoTime - timeStarted)
+      logger.error(s"Error occurred during processing in ${duration.getSeconds} seconds ($duration): $err")
+      ExitCode.Error
+    }, _ => {
+      val duration = Duration.ofNanos(System.nanoTime - timeStarted)
+      logger.info(
+        s"Completed generating results for articles in ${duration.getSeconds} seconds ($duration)"
       )
+      ExitCode.Success
+    })
+  }
+
+  def processEntries(conf: RoboCORD.Conf): Stream[IO, Unit] = {
+    // Set up Annotator.
+    val annotator: Annotator = new Annotator(conf.neo4jLocation())
+
+    // Load the metadata file.
+    val csvReader = CSVReader.open(conf.metadata())
+    val (headers: List[String], allMetadata: List[Map[String, String]]) = csvReader.allWithOrderedHeaders()
+    logger.info(s"Loaded ${allMetadata.size} articles from metadata file ${conf.metadata()}.")
+
+    // Let's make sure the loaded metadata is what we expect -- if not, fields might have changed unexpectedly!
+    assert(headers == List(
+      "cord_uid",
+      "sha",
+      "source_x",
+      "title",
+      "doi",
+      "pmcid",
+      "pubmed_id",
+      "license",
+      "abstract",
+      "publish_time",
+      "authors",
+      "journal",
+      "mag_id",
+      "who_covidence_id",
+      "arxiv_id",
+      "pdf_json_files",
+      "pmc_json_files",
+      "url",
+      "s2_id"
+    ))
+
+    // Which metadata entries do we actually need to process?
+    val startIndex = conf.fromRow.toOption.get
+    val endIndex = conf.untilRow.toOption.get
+
+    // Do we already have an output file? If so, we abort.
+    val inProgressFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.in-progress.txt"
+    val inProgressFile = new File(inProgressFilename)
+    if (inProgressFile.exists()) {
+      if (inProgressFile.delete())
+        logger.info(s"In-progress output file '${inProgressFilename}' already exists and has been deleted.")
+      else {
+        logger.info(s"In-progress output file '${inProgressFilename}' already exists but could not be deleted.")
+        System.exit(2)
+      }
     }
 
-    // Extract annotations from the full text using SciGraph.
-    val (parsedFullText, annotations) = annotator.extractAnnotations(fullText.replaceAll("\\s+", " "))
+    val outputFilename = conf.outputPrefix() + s"_from_${startIndex}_until_$endIndex.tsv"
+    if (new File(outputFilename).length > 0) {
+      logger.info(s"Output file '${outputFilename}' already exists, skipping.")
+      System.exit(0)
+    }
 
-    // Write them all out.
-    articlesCompleted += 1
-    val articlesPercentage = f"${articlesCompleted.toFloat / articlesTotal * 100}%.2f%%"
-    logger.info(s"Identified ${annotations.size} annotations for article $id $withFullText (approx $articlesCompleted out of $articlesTotal, $articlesPercentage)")
-    annotations.map(annotation => {
-      val matchedString = parsedFullText.slice(annotation.getStart, annotation.getEnd).replaceAll("\\s+", " ")
-      val preText = parsedFullText.slice(annotation.getStart - conf.context(), annotation.getStart).replaceAll("\\s+", " ")
-      val postText = parsedFullText.slice(annotation.getEnd, annotation.getEnd + conf.context()).replaceAll("\\s+", " ")
-      s"""$id\t$articleId\t${if (pmcid == "") "" else s"PMCID:$pmcid"}\t$withFullText\t"$preText"\t"$matchedString"\t"$postText"\t${annotation.getToken.getId}\t${annotation.toString}"""
-    })
-  })
+    // Divide allMetadata into chunks based on totalChunks.
+    val metadata: Seq[Map[String, String]] = allMetadata.slice(startIndex, endIndex)
+    val articlesTotal = metadata.size
+    logger.info(s"Selected $articlesTotal articles for processing (from $startIndex until $endIndex)")
 
-  // Write out all the results to the output file.
-  logger.info(s"Writing tab-delimited output to $outputFilename.")
-  val pw = new PrintWriter(new FileWriter(new File(inProgressFilename)))
-  results.foreach(pw.println(_))
-  pw.close
+    // Use the FS2 Streams API to process the rows we need to.
+    val metadataStream = Stream.emits(metadata.zipWithIndex)
 
-  val duration = Duration.ofNanos(System.nanoTime - timeStarted)
-  logger.info(s"Completed generating ${results.size} results for $articlesTotal articles in ${duration.getSeconds} seconds ($duration)")
+    // Step 1. Convert the metadata into a tab-delimited format and choose a full-text document to annotate.
+    val preAnnotationStream: Stream[IO, (String, String)] = {
+      metadataStream.map({
+        case (entry, index) =>
+          // Find the ID of this article.
+          // We have some duplicate CORD_UIDs (yes, really!). So we add the metadata row index to make it fully unique.
+          val id = s"${entry("cord_uid")}:${startIndex + index}"
+          val pmid = entry.get("pubmed_id")
+          val doi = entry.get("doi")
 
-  Files.move(
-    new File(inProgressFilename).toPath,
-    new File(outputFilename).toPath,
-    StandardCopyOption.REPLACE_EXISTING
-  )
-  logger.info(s"Renamed ${inProgressFilename} to ${outputFilename}; file ready for use.")
+          // It looks like there are no articles with multiple duplicate PMCIDs, but let's be paranoid
+          // and use only the last one.
+          val pmcids = entry.getOrElse("pmcid", "").split(';').map(_.trim).filter(_.nonEmpty)
+          val pmcid = if (pmcids.length > 1) {
+            val pmcidLast = pmcids.last
+            logger.info(s"Found multiple PMCIDs for $id, choosing the last one ($pmcidLast) out of: $pmcids")
+            pmcidLast
+          } else pmcids.headOption.getOrElse("")
+
+          // Choose an "article ID", which is one of: (1) PubMed ID, (2) DOI, (3) PMCID or (4) CORD_UID.
+          val articleId = if (pmid.nonEmpty && pmid.get.nonEmpty) pmid.map("PMID:" + _).mkString("|")
+          else if (doi.nonEmpty && doi.get.nonEmpty) doi.map("DOI:" + _).mkString("|")
+          else if (pmcid.nonEmpty) s"PMCID:${pmcid}"
+          else s"CORD_UID:$id"
+
+          // Full-text articles are stored by path. We might have multiple PMC or PDF parses; we prioritize PMC over PDF.
+          val pmcJSONFiles = entry("pmc_json_files").split(';').map(_.trim).filter(_.nonEmpty)
+          val pdfJSONFiles = entry("pdf_json_files").split(';').map(_.trim).filter(_.nonEmpty)
+          val fullTextFilename: String = if (pmcJSONFiles.nonEmpty) {
+            if (pmcJSONFiles.length == 1) pmcJSONFiles.head
+            else {
+              val pmcLast = pmcJSONFiles.last
+              logger.info(s"Found multiple PMC JSON files, choosing the last one ($pmcLast) out of $pmcJSONFiles")
+              pmcLast
+            }
+          } else if (pdfJSONFiles.nonEmpty) {
+            if (pdfJSONFiles.length == 1) pdfJSONFiles.head
+            else {
+              val pdfLast = pdfJSONFiles.last
+              logger.info(s"Found multiple PDF JSON files, choosing the last one ($pdfLast) out of $pdfJSONFiles")
+              pdfLast
+            }
+          } else ""
+
+          val (fullText, withFullText) = if (fullTextFilename.nonEmpty) {
+            val jsonReader = CORDJsonReader.wrapFile(new File(new File("robocord-data"), fullTextFilename), logger)
+            (jsonReader.map(_.fullText).mkString("\n===\n"), s"with full text from $fullTextFilename")
+          } else {
+            // We don't have full text, so just annotate the title and abstract.
+            val title: String = entry.getOrElse("title", "")
+            val abstractText = entry.getOrElse("abstract", "")
+            (
+              s"$title\n$abstractText",
+              "without full text"
+            )
+          }
+
+          // We return a tuple: the preamble followed by the full text to annotate.
+          (
+            s"""$id\t$articleId\t${if (pmcid == "") "" else s"PMCID:$pmcid"}\t$withFullText""",
+            fullText
+          )
+      })
+    }
+
+    // Step 2. Annotate full texts, and concatenate annotations with metadata to produce final output.
+    val annotationStream: Stream[IO, String] = preAnnotationStream
+      .debug(metadata => s"Processing ${metadata._1}")
+      .flatMap({
+        case (metadataString, fullText) =>
+          // Extract annotations from the full text using SciGraph.
+          val (parsedFullText, annotations) =
+            annotator.extractAnnotations(fullText.replaceAll("\\s+", " "))
+
+          // Write them all out.
+          Stream.emits(annotations.map(annotation => {
+            val matchedString =
+              parsedFullText.slice(annotation.getStart, annotation.getEnd).replaceAll("\\s+", " ")
+            val preText = parsedFullText
+              .slice(annotation.getStart - conf.context(), annotation.getStart)
+              .replaceAll("\\s+", " ")
+            val postText = parsedFullText
+              .slice(annotation.getEnd, annotation.getEnd + conf.context())
+              .replaceAll("\\s+", " ")
+
+            s"""${metadataString}\t"$preText"\t"$matchedString"\t"$postText"\t${annotation.getToken.getId}\t${annotation.toString}"""
+          }))
+      })
+
+    // Write all outputs to the in-progress file.
+    logger.info(s"Writing tab-delimited output to $inProgressFile.")
+    implicit val ioContextShift: ContextShift[IO] =
+      IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
+    val finalStream: Stream[IO, Unit] = Stream.resource(Blocker[IO]).flatMap { blocker =>
+      annotationStream
+        .intersperse("\n")
+        .through(text.utf8Encode)
+        .through(io.file.writeAll(inProgressFile.toPath, blocker))
+        .onComplete(Stream.eval(IO {
+          logger.info(s"Completed writing ${inProgressFilename}; moving to ${outputFilename}.")
+
+          Files.move(
+            inProgressFile.toPath,
+            new File(outputFilename).toPath,
+            StandardCopyOption.REPLACE_EXISTING
+          )
+
+          logger.info(s"Renamed ${inProgressFilename} to ${outputFilename}; file ready for use.")
+        }))
+    }
+
+    finalStream
+  }
 }

--- a/src/main/scala/org/renci/robocord/RoboCORDManager.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORDManager.scala
@@ -7,15 +7,16 @@ import java.io.File
 import java.util.concurrent.TimeUnit
 
 import com.github.tototoshi.csv.CSVReader
+import scala.util.matching.Regex
 
 /**
- * RoboCORD Manager manages runs of the RoboCORD Worker. Since we run RoboCORD on a SLURM-based cluster,
- * we have a manager that starts workers using `srun` to fill in gaps that need executing.
- */
+  * RoboCORD Manager manages runs of the RoboCORD Worker. Since we run RoboCORD on a SLURM-based cluster,
+  * we have a manager that starts workers using `srun` to fill in gaps that need executing.
+  */
 object RoboCORDManager extends App {
   /**
-   * Command line configuration for RoboCORDManager.
-   */
+    * Command line configuration for RoboCORDManager.
+    */
   class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
     override def onError(e: Throwable): Unit = e match {
       case ScallopException(message) =>
@@ -33,7 +34,8 @@ object RoboCORDManager extends App {
       default = Some(new File("robocord-data/metadata.csv"))
     )
     val outputDir: ScallopOption[File] = opt[File](
-      descr = "Directory containing output files. Our output files are in the format '$outputDir/result_from_{index}_until_{index}.txt'",
+      descr =
+        "Directory containing output files. Our output files are in the format '$outputDir/result_from_{index}_until_{index}.txt'",
       default = Some(new File("robocord-output"))
     )
     val neo4jLocation: ScallopOption[File] = opt[File](
@@ -44,18 +46,15 @@ object RoboCORDManager extends App {
       descr = "How many characters before and after the matched term should be displayed.",
       default = Some(50)
     )
-    val jobSize: ScallopOption[Int] = opt[Int](
-      descr = "The maximum number of rows in each job.",
-      default = Some(500)
-    )
+    val jobSize: ScallopOption[Int] =
+      opt[Int](descr = "The maximum number of rows in each job.", default = Some(500))
     val dryRun: ScallopOption[Boolean] = opt[Boolean](
-      descr = "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
+      descr =
+        "If true, perform a dry run: display the srun commands to be executed, but don't actually execute them.",
       default = Some(false)
     )
-    val tryOne: ScallopOption[Boolean] = opt[Boolean](
-      descr = "If true, try executing a single job.",
-      default = Some(false)
-    )
+    val tryOne: ScallopOption[Boolean] =
+      opt[Boolean](descr = "If true, try executing a single job.", default = Some(false))
     val cmdDelay: ScallopOption[Int] = opt[Int](
       descr = "The number of seconds to wait before running the subsequent job.",
       default = Some(2)
@@ -68,51 +67,60 @@ object RoboCORDManager extends App {
   val conf = new Conf(args)
 
   // Load the metadata file.
-  val csvReader = CSVReader.open(conf.metadata())
-  val (headers: List[String], metadata: List[Map[String, String]]) = csvReader.allWithOrderedHeaders()
+  val csvReader: CSVReader = CSVReader.open(conf.metadata())
+  val (headers: List[String], metadata: List[Map[String, String]]) =
+    csvReader.allWithOrderedHeaders()
   scribe.info(s"Loaded ${metadata.size} articles from metadata file ${conf.metadata()}.")
 
   // Get all existing output files.
-  val filenameRegex = """result_from_(\d+)_until_(\d+).tsv""".r
+  val filenameRegex: Regex = """result_from_(\d+)_until_(\d+).tsv""".r
   val existingRangesSorted: Seq[Range] = conf.outputDir
     .getOrElse(new File("robocord-output"))
     .listFiles()
     .toSeq
     .filter(file => file.getName.startsWith("result_") && file.getName.endsWith(".tsv"))
-    .map(file => file.getName match {
-      case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
-      case _ => throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
-    })
+    .map(
+      file =>
+        file.getName match {
+          case filenameRegex(from, until) => new Range(from.toInt, until.toInt, 1)
+          case _ =>
+            throw new RuntimeException(s"Unexpected result filename found: ${file.getName}.")
+        }
+    )
     .sortBy(_.start)
 
   scribe.info(s"Ranges completed: ${existingRangesSorted}")
 
   // We can now generate a set of ranges that work around those that have already been generated.
-  val rangesToProcess: Seq[Range] = if (existingRangesSorted.isEmpty) Seq(metadata.indices) else {
-    val rangesToExclude = (
-      new Range(metadata.indices.head, metadata.indices.head, 1)
-      +: existingRangesSorted :+
-      new Range(metadata.size, metadata.size, 1)
-    )
-    scribe.info(s"Ranges to exclude: ${rangesToExclude}")
-    scribe.info(s"Sliding ranges to exclude: ${rangesToExclude.sliding(2).toSeq}")
-    rangesToExclude
-      .sliding(2) // Group them up in pairs, i.e. indexes (0, 1), (1, 2), (2, 3), ...
-      .map({
-        // For each pair, choose the range from the end of the first range to the start of the next range
-        case Seq(prev, next) => Range(prev.end, next.start)
-      })
-      .filter(_.nonEmpty) // Some of these ranges may be empty (e.g. 640 to 640); we can exclude those.
-      .toSeq
-  }
+  val rangesToProcess: Seq[Range] =
+    if (existingRangesSorted.isEmpty) Seq(metadata.indices)
+    else {
+      val rangesToExclude = (
+        new Range(metadata.indices.head, metadata.indices.head, 1)
+          +: existingRangesSorted :+
+          new Range(metadata.size, metadata.size, 1)
+      )
+      scribe.info(s"Ranges to exclude: ${rangesToExclude}")
+      scribe.info(s"Sliding ranges to exclude: ${rangesToExclude.sliding(2).toSeq}")
+      rangesToExclude
+        .sliding(2) // Group them up in pairs, i.e. indexes (0, 1), (1, 2), (2, 3), ...
+        .map({
+          // For each pair, choose the range from the end of the first range to the start of the next range
+          case Seq(prev, next) => Range(prev.end, next.start)
+        })
+        .filter(_.nonEmpty) // Some of these ranges may be empty (e.g. 640 to 640); we can exclude those.
+        .toSeq
+    }
   scribe.info(s"Ranges to process: ${rangesToProcess.mkString(", ")}")
 
   // Generate warnings for overlapping output files.
   val existingRanges = existingRangesSorted.toSet
   existingRanges.foreach(range => {
-    existingRanges.filter(r => r != range && r.intersect(range).nonEmpty).foreach(r => {
-      scribe.warn(s"Output files are present for both ${range} and ${r}")
-    })
+    existingRanges
+      .filter(r => r != range && r.intersect(range).nonEmpty)
+      .foreach(r => {
+        scribe.warn(s"Output files are present for both ${range} and ${r}")
+      })
   })
 
   if (rangesToProcess.isEmpty) {
@@ -123,7 +131,7 @@ object RoboCORDManager extends App {
   var jobCount = 0
   def processJob(range: Range): Unit = {
     if (range.size > conf.jobSize.getOrElse(200)) {
-      val halfway: Int = range.start + range.size/2
+      val halfway: Int = range.start + range.size / 2
       processJob(new Range(range.start, halfway, 1))
       processJob(new Range(halfway, range.end, 1))
     } else {
@@ -135,10 +143,14 @@ object RoboCORDManager extends App {
         val cmd = Seq(
           "/bin/bash",
           "robocord-sbatch.sh",
-          "--metadata", "robocord-data/metadata.csv",
-          "--from-row", range.start.toString,
-          "--until-row", range.end.toString,
-          "--output-prefix", "robocord-output/result",
+          "--metadata",
+          "robocord-data/metadata.csv",
+          "--from-row",
+          range.start.toString,
+          "--until-row",
+          range.end.toString,
+          "--output-prefix",
+          "robocord-output/result",
           "robocord-data"
         )
         val process = cmd.run(logger)
@@ -146,7 +158,7 @@ object RoboCORDManager extends App {
           scribe.info(s" - Executed job ${jobCount}: ${range} (size: ${range.size}): ${cmd}")
         else
           scribe.error(s" - Could not execute job ${jobCount}: ${range} (size: ${range.size})")
-        if(conf.tryOne.getOrElse(false)) System.exit(0)
+        if (conf.tryOne.getOrElse(false)) System.exit(0)
         TimeUnit.SECONDS.sleep(conf.cmdDelay.getOrElse(2))
       }
     }

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -4,7 +4,12 @@ import java.io.{File, StringReader}
 import java.util.HashMap
 
 import com.typesafe.scalalogging.LazyLogging
-import io.scigraph.annotation.{EntityAnnotation, EntityFormatConfiguration, EntityProcessorImpl, EntityRecognizer}
+import io.scigraph.annotation.{
+  EntityAnnotation,
+  EntityFormatConfiguration,
+  EntityProcessorImpl,
+  EntityRecognizer
+}
 import io.scigraph.neo4j.NodeTransformer
 import io.scigraph.vocabulary.{Vocabulary, VocabularyNeo4jImpl}
 import org.apache.lucene.queryparser.classic.QueryParserBase
@@ -18,8 +23,10 @@ import scala.collection.JavaConverters._
 class Annotator(neo4jLocation: File) extends LazyLogging {
   private val curieUtil: CurieUtil         = new CurieUtil(new HashMap())
   private val transformer: NodeTransformer = new NodeTransformer()
-  private val graphDB: GraphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase(neo4jLocation)
-  private val vocabulary: Vocabulary = new VocabularyNeo4jImpl(graphDB, neo4jLocation.getAbsolutePath, curieUtil, transformer)
+  private val graphDB: GraphDatabaseService =
+    new GraphDatabaseFactory().newEmbeddedDatabase(neo4jLocation)
+  private val vocabulary: Vocabulary =
+    new VocabularyNeo4jImpl(graphDB, neo4jLocation.getAbsolutePath, curieUtil, transformer)
   private val recognizer = new EntityRecognizer(vocabulary, curieUtil)
 
   val processor = new EntityProcessorImpl(recognizer)
@@ -30,8 +37,8 @@ class Annotator(neo4jLocation: File) extends LazyLogging {
   def extractAnnotations(str: String): (String, List[EntityAnnotation]) = {
     val parsedString = QueryParserBase.escape(str)
     val configBuilder = new EntityFormatConfiguration.Builder(new StringReader(parsedString))
-        .longestOnly(true)
-        .minLength(3)
+      .longestOnly(true)
+      .minLength(3)
     (parsedString, processor.annotateEntities(configBuilder.get).asScala.toList)
   }
 }


### PR DESCRIPTION
This PR replaces the Scala parallel collections with FS2 streams. This is a very rough first attempt, based on the example provided on the [FS2 Github page](https://github.com/typelevel/fs2#example), which I expect I'll refine over time. It also improves the `robocord-test` Makefile target so as to be faster. I also used scalafix and scalafmt to clean up the code.

Note that this PR specifically does not include a fix for the annotation index bug that was previously fixed in #76 -- I figure it'd be simpler to include FS2 streams, and then fix the issue with SciGraph in another PR (#79).