### PR TITLE
Fixed indexing bug and improved matched term generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ jdk:
 # Cache Maven and SBT packages so we don't need to keep reinstalling them.
 cache:
   directories:
-  - $HOME/.m2
+  - $HOME/.cache/coursier
+  - $HOME/.ivy2/cache
   - $HOME/.sbt
+  - $HOME/.m2
 
 # We need to install SciGraph to run Omnicorp for testing.
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ pubmed-annual-baseline/done:
 	touch pubmed-annual-baseline/done
 
 SciGraph:
-	git clone https://github.com/balhoff/SciGraph.git &&\
+	git clone https://github.com/gaurav/SciGraph.git &&\
 	cd SciGraph &&\
-	git checkout public-constructors &&\
+	git checkout public-constructors-and-methods &&\
 	mvn -B -DskipTests -DskipITs install
 
 robot.jar:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ robocord-test: SciGraph
 		ln -s robocord-outputs/${ROBOCORD_DATE} robocord-output; \
 	fi
 
+	sbt test
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 512 --until-row 440 robocord-data"
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 640 --until-row 668  robocord-data"
 	JAVA_OPTS="-Xmx$(MEMORY)" sbt "runMain org.renci.robocord.RoboCORD --metadata robocord-data/metadata.csv --from-row 768 --until-row 796  robocord-data"

--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,8 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 
 // Dependency information.
 
-// I'm currently running into an issue when updating existing libraries in
-// running srun stalls for a long period of time. This should fix it temporarily.
+// Our cluster doesn't allow worker nodes to access the internet;
+// we therefore go into offline mode when running the code using `sbt`.
 offline in run := true
 
 resolvers += Resolver.mavenLocal

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,10 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 
 // Dependency information.
 
+// I'm currently running into an issue when updating existing libraries in
+// running srun stalls for a long period of time. This should fix it temporarily.
+offline := true
+
 resolvers += Resolver.mavenLocal
 
 libraryDependencies ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ testFrameworks += new TestFramework("utest.runner.Framework")
 
 // I'm currently running into an issue when updating existing libraries in
 // running srun stalls for a long period of time. This should fix it temporarily.
-offline := true
+offline in run := true
 
 resolvers += Resolver.mavenLocal
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,8 @@ libraryDependencies ++= {
     "org.backuity.clist"          %% "clist-macros"           % "3.2.2" % "provided",
     "com.typesafe.akka"           %% "akka-stream"            % "2.5.9",
     "org.scala-lang.modules"      %% "scala-xml"              % "1.0.6",
-    "io.scigraph"                 %  "scigraph-core"          % "2.1-SNAPSHOT",
-    "io.scigraph"                 %  "scigraph-entity"        % "2.1-SNAPSHOT",
+    "io.scigraph"                 %  "scigraph-core"          % "2.2-SNAPSHOT",
+    "io.scigraph"                 %  "scigraph-entity"        % "2.2-SNAPSHOT",
     "org.codehaus.groovy"         %  "groovy-all"             % "2.4.6",
     "org.apache.jena"             %  "apache-jena-libs"       % "3.13.1",
 

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -59,11 +59,11 @@ object RoboCORD extends IOApp with LazyLogging {
   }
 
   /**
-   * Main method for a FS2 IO App.
-   *
-   * @param args Command line arguments.
-   * @return Exit code.
-   */
+    * Main method for a FS2 IO App.
+    *
+    * @param args Command line arguments.
+    * @return Exit code.
+    */
   def run(args: List[String]): IO[ExitCode] = {
     // Parse command line arguments.
     val conf = new Conf(args, logger)
@@ -90,12 +90,12 @@ object RoboCORD extends IOApp with LazyLogging {
   }
 
   /**
-   * Generate a FS2 Stream for processing the rows in the metadata file as described
-   * in the command line arguments.
-   *
-   * @param conf Parsed command line options
-   * @return An FS2 Stream for processing the rows in the metadata file. Use `.drain` to actually execute the stream.
-   */
+    * Generate a FS2 Stream for processing the rows in the metadata file as described
+    * in the command line arguments.
+    *
+    * @param conf Parsed command line options
+    * @return An FS2 Stream for processing the rows in the metadata file. Use `.drain` to actually execute the stream.
+    */
   def processEntries(conf: RoboCORD.Conf): Stream[IO, Unit] = {
     // Set up Annotator.
     val annotator: Annotator = new Annotator(conf.neo4jLocation())

--- a/src/main/scala/org/renci/robocord/RoboCORD.scala
+++ b/src/main/scala/org/renci/robocord/RoboCORD.scala
@@ -263,7 +263,9 @@ object RoboCORD extends IOApp with LazyLogging {
               .slice(annotation.getEnd, annotation.getEnd + conf.context())
               .replaceAll("\\s+", " ")
 
-            s"""$metadataString\t"$preText"\t"$matchedString"\t"$postText"\t${annotation.getToken.getId}\t${annotation.toString}"""
+            val cleanedString = Annotator.removeStopCharacters(matchedString)
+
+            s"""$metadataString\t"$preText"\t"$matchedString"\t"$cleanedString\"\t"$postText"\t${annotation.getToken.getId}\t${annotation.toString}"""
           }))
       })
 

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -50,14 +50,14 @@ object Annotator {
     matchedString
       // TODO: we currently see "pig\-tailed macaques \(a" -> "pig-tailed macaques \(".
       // Maybe unescape all "\x" to "x"?
-      .replaceAll("^\\W+", "")              // Remove leading non-word characters.
-      .replaceAll("\\W+$", "")              // Remove trailing non-word characters.
-      .replaceAll("\\\\-", "-")             // Unescape dashes.
       .split("\\b+")                                   // Split at word boundaries.
       .map(_.trim)                                            // Trim all strings.
       .filter(!_.isEmpty)                                     // Remove all empty strings.
       .filter(str => !StopAnalyzer.ENGLISH_STOP_WORDS_SET.contains(str.toLowerCase))    // Filter out stop words.
       .mkString(" ")                                          // Recombine into a single string.
+      .replaceAll("^\\W+", "")              // Remove leading non-word characters.
+      .replaceAll("\\W+$", "")              // Remove trailing non-word characters.
+      .replaceAll("\\\\-", "-")             // Unescape dashes.
       .replaceAll("\\s+-\\s+", "-")         // Remove spaces around dashes.
       .trim                                                   // Make sure we don't have any leading/trailing spaces left over.
   }

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -36,9 +36,9 @@ class Annotator(neo4jLocation: File) extends LazyLogging {
   /** Extract annotations from a particular string using SciGraph. */
   def extractAnnotations(str: String): (String, List[EntityAnnotation]) = {
     val parsedString = QueryParserBase.escape(str)
-    val configBuilder = new EntityFormatConfiguration.Builder(new StringReader(parsedString))
-      .longestOnly(true)
-      .minLength(3)
-    (parsedString, processor.annotateEntities(configBuilder.get).asScala.toList)
+    val configBuilder = new EntityFormatConfiguration.Builder(new StringReader(""))
+        .longestOnly(true)
+        .minLength(3)
+    (parsedString, processor.getAnnotations(parsedString, configBuilder.get).asScala.toList)
   }
 }

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -48,17 +48,17 @@ object Annotator {
   /** Remove stop characters from matched string. */
   def removeStopCharacters(matchedString: String): String = {
     matchedString
-    // TODO: we currently see "pig\-tailed macaques \(a" -> "pig-tailed macaques \(".
-    // Maybe unescape all "\x" to "x"?
-      .split("\\b+")                                                                 // Split at word boundaries.
+      .split("\\b+")                                                         // Split at word boundaries.
       .map(_.trim)                                                                   // Trim all strings.
       .filter(!_.isEmpty)                                                            // Remove all empty strings.
       .filter(str => !StopAnalyzer.ENGLISH_STOP_WORDS_SET.contains(str.toLowerCase)) // Filter out stop words.
+      .map(word => word
+        .replaceAll("\\\\(.)", "$1")                               // Unescape everything.
+      )
       .mkString(" ")                                                                 // Recombine into a single string.
-      .replaceAll("^\\W+", "")                                                       // Remove leading non-word characters.
-      .replaceAll("\\W+$", "")                                                       // Remove trailing non-word characters.
-      .replaceAll("\\\\-", "-")                                                      // Unescape dashes.
-      .replaceAll("\\s+-\\s+", "-")                                                  // Remove spaces around dashes.
+      .replaceAll("^\\W+", "")                                     // Remove leading non-word characters.
+      .replaceAll("\\W+$", "")                                     // Remove trailing non-word characters.
+      .replaceAll("\\s+(\\p{Punct})\\s+", "$1")                    // Remove spaces around punctuation.
       .trim                                                                          // Make sure we don't have any leading/trailing spaces left over.
   }
 }

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -38,8 +38,8 @@ class Annotator(neo4jLocation: File) extends LazyLogging {
   def extractAnnotations(str: String): (String, List[EntityAnnotation]) = {
     val parsedString = QueryParserBase.escape(str)
     val configBuilder = new EntityFormatConfiguration.Builder(new StringReader(""))
-        .longestOnly(true)
-        .minLength(3)
+      .longestOnly(true)
+      .minLength(3)
     (parsedString, processor.getAnnotations(parsedString, configBuilder.get).asScala.toList)
   }
 }
@@ -48,17 +48,17 @@ object Annotator {
   /** Remove stop characters from matched string. */
   def removeStopCharacters(matchedString: String): String = {
     matchedString
-      // TODO: we currently see "pig\-tailed macaques \(a" -> "pig-tailed macaques \(".
-      // Maybe unescape all "\x" to "x"?
-      .split("\\b+")                                   // Split at word boundaries.
-      .map(_.trim)                                            // Trim all strings.
-      .filter(!_.isEmpty)                                     // Remove all empty strings.
-      .filter(str => !StopAnalyzer.ENGLISH_STOP_WORDS_SET.contains(str.toLowerCase))    // Filter out stop words.
-      .mkString(" ")                                          // Recombine into a single string.
-      .replaceAll("^\\W+", "")              // Remove leading non-word characters.
-      .replaceAll("\\W+$", "")              // Remove trailing non-word characters.
-      .replaceAll("\\\\-", "-")             // Unescape dashes.
-      .replaceAll("\\s+-\\s+", "-")         // Remove spaces around dashes.
-      .trim                                                   // Make sure we don't have any leading/trailing spaces left over.
+    // TODO: we currently see "pig\-tailed macaques \(a" -> "pig-tailed macaques \(".
+    // Maybe unescape all "\x" to "x"?
+      .split("\\b+")                                                                 // Split at word boundaries.
+      .map(_.trim)                                                                   // Trim all strings.
+      .filter(!_.isEmpty)                                                            // Remove all empty strings.
+      .filter(str => !StopAnalyzer.ENGLISH_STOP_WORDS_SET.contains(str.toLowerCase)) // Filter out stop words.
+      .mkString(" ")                                                                 // Recombine into a single string.
+      .replaceAll("^\\W+", "")                                                       // Remove leading non-word characters.
+      .replaceAll("\\W+$", "")                                                       // Remove trailing non-word characters.
+      .replaceAll("\\\\-", "-")                                                      // Unescape dashes.
+      .replaceAll("\\s+-\\s+", "-")                                                  // Remove spaces around dashes.
+      .trim                                                                          // Make sure we don't have any leading/trailing spaces left over.
   }
 }

--- a/src/main/scala/org/renci/robocord/annotator/Annotator.scala
+++ b/src/main/scala/org/renci/robocord/annotator/Annotator.scala
@@ -48,17 +48,19 @@ object Annotator {
   /** Remove stop characters from matched string. */
   def removeStopCharacters(matchedString: String): String = {
     matchedString
-      .split("\\b+")                                                         // Split at word boundaries.
+      .split("\\b+")                                                                 // Split at word boundaries.
       .map(_.trim)                                                                   // Trim all strings.
       .filter(!_.isEmpty)                                                            // Remove all empty strings.
       .filter(str => !StopAnalyzer.ENGLISH_STOP_WORDS_SET.contains(str.toLowerCase)) // Filter out stop words.
-      .map(word => word
-        .replaceAll("\\\\(.)", "$1")                               // Unescape everything.
+      .map(
+        word =>
+          word
+            .replaceAll("\\\\(.)", "$1") // Unescape everything.
       )
-      .mkString(" ")                                                                 // Recombine into a single string.
-      .replaceAll("^\\W+", "")                                     // Remove leading non-word characters.
-      .replaceAll("\\W+$", "")                                     // Remove trailing non-word characters.
-      .replaceAll("\\s+(\\p{Punct})\\s+", "$1")                    // Remove spaces around punctuation.
-      .trim                                                                          // Make sure we don't have any leading/trailing spaces left over.
+      .mkString(" ")                            // Recombine into a single string.
+      .replaceAll("^\\W+", "")                  // Remove leading non-word characters.
+      .replaceAll("\\W+$", "")                  // Remove trailing non-word characters.
+      .replaceAll("\\s+(\\p{Punct})\\s+", "$1") // Remove spaces around punctuation.
+      .trim                                     // Make sure we don't have any leading/trailing spaces left over.
   }
 }

--- a/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
+++ b/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
@@ -16,7 +16,12 @@ object AnnotatorUnitTests extends TestSuite {
           "nephrotic syndrome."        -> "nephrotic syndrome",
           "\\(Figure"                  -> "Figure",
           "\\(C\\),"                   -> "C",
-          "pig\\-tailed macaques \\(a" -> "pig-tailed macaques"
+          "pig\\-tailed macaques \\(a" -> "pig-tailed macaques",
+          ". And ACE2"                 -> "ACE2",
+          "ACE2. (A)"         -> "ACE2",
+          "HERC5 (the"-> "HERC5",
+          "Herc5 (the"-> "Herc5",
+          "(such as HERC5" -> "HERC5"
         )
 
         examples.foreach({

--- a/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
+++ b/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
@@ -1,0 +1,34 @@
+package org.renci.robocord
+
+import org.renci.robocord.annotator.Annotator
+
+import utest._
+
+/**
+  * Unit tests for the RoboCORD Annotator class.
+  */
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.TryPartial",       // We use Try.get() in a
+    "org.wartremover.warts.NonUnitStatements" // non-unit statements to test whether parsing fails correctly.
+  )
+)
+object AnnotatorUnitTests extends TestSuite {
+  val tests = Tests {
+    test("Annotator") {
+      test("#removeStopCharacters") {
+        val examples = Map(
+          "H1N1 virus infection\\:" -> "H1N1 virus infection",
+          "nephrotic syndrome." -> "nephrotic syndrome",
+          "\\(Figure" -> "Figure",
+          "\\(C\\)," -> "C"
+        )
+
+        examples.foreach({ case (example, expected) =>
+          val obtained = Annotator.removeStopCharacters(example)
+          assert(expected == obtained)
+        })
+      }
+    }
+  }
+}

--- a/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
+++ b/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
@@ -15,7 +15,8 @@ object AnnotatorUnitTests extends TestSuite {
           "H1N1 virus infection\\:" -> "H1N1 virus infection",
           "nephrotic syndrome." -> "nephrotic syndrome",
           "\\(Figure" -> "Figure",
-          "\\(C\\)," -> "C"
+          "\\(C\\)," -> "C",
+          "pig\\-tailed macaques \\(a" -> "pig-tailed macaques"
         )
 
         examples.foreach({ case (example, expected) =>

--- a/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
+++ b/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
@@ -18,10 +18,11 @@ object AnnotatorUnitTests extends TestSuite {
           "\\(C\\),"                   -> "C",
           "pig\\-tailed macaques \\(a" -> "pig-tailed macaques",
           ". And ACE2"                 -> "ACE2",
-          "ACE2. (A)"         -> "ACE2",
-          "HERC5 (the"-> "HERC5",
-          "Herc5 (the"-> "Herc5",
-          "(such as HERC5" -> "HERC5"
+          "ACE2. (A)"                  -> "ACE2",
+          "HERC5 (the"                 -> "HERC5",
+          "Herc5 (the"                 -> "Herc5",
+          "(such as HERC5"             -> "HERC5",
+          "field's"                    -> "field's"
         )
 
         examples.foreach({

--- a/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
+++ b/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
@@ -7,12 +7,6 @@ import utest._
 /**
   * Unit tests for the RoboCORD Annotator class.
   */
-@SuppressWarnings(
-  Array(
-    "org.wartremover.warts.TryPartial",       // We use Try.get() in a
-    "org.wartremover.warts.NonUnitStatements" // non-unit statements to test whether parsing fails correctly.
-  )
-)
 object AnnotatorUnitTests extends TestSuite {
   val tests = Tests {
     test("Annotator") {

--- a/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
+++ b/src/test/scala/org/renci/robocord/AnnotatorUnitTests.scala
@@ -12,16 +12,17 @@ object AnnotatorUnitTests extends TestSuite {
     test("Annotator") {
       test("#removeStopCharacters") {
         val examples = Map(
-          "H1N1 virus infection\\:" -> "H1N1 virus infection",
-          "nephrotic syndrome." -> "nephrotic syndrome",
-          "\\(Figure" -> "Figure",
-          "\\(C\\)," -> "C",
+          "H1N1 virus infection\\:"    -> "H1N1 virus infection",
+          "nephrotic syndrome."        -> "nephrotic syndrome",
+          "\\(Figure"                  -> "Figure",
+          "\\(C\\),"                   -> "C",
           "pig\\-tailed macaques \\(a" -> "pig-tailed macaques"
         )
 
-        examples.foreach({ case (example, expected) =>
-          val obtained = Annotator.removeStopCharacters(example)
-          assert(expected == obtained)
+        examples.foreach({
+          case (example, expected) =>
+            val obtained = Annotator.removeStopCharacters(example)
+            assert(expected == obtained)
         })
       }
     }


### PR DESCRIPTION
This PR fixes the indexing issue we were facing earlier. Those checks have now been incorporated into SciGraph's master branch (https://github.com/SciGraph/SciGraph/pull/281), but I decided to use `getAnnotations()` method (which is designed to be used with plain text) instead of the `annotateEntities()` method (which is designed to be used with HTML content). To do that, we use a branch of SciGraph with those modifications (https://github.com/SciGraph/SciGraph/pull/285).

Additionally, this PR adds a field to the output file that has the matched term with all stop terms removed (fixes #77) and adds tests for that.

Should be merged after #78.