### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,44 @@
 
 Extract ontology terms referenced from PubMed abstracts as per the [MEDLINE/PubMed Baseline Repository](https://mbr.nlm.nih.gov/) by using [SciGraph](https://github.com/SciGraph/SciGraph) against a set of ontologies.
 
+## Prerequisites
+
+Using OmniCorp requires the following open source tools:
+- Git
+- Maven
+- Scala and sbt
+- wget
+
+On macOS, these can be installed [using Homebrew](https://brew.sh/) by running
+the command: `brew install git maven scala sbt wget`.
+
+## Setting up SciGraph
+
+We need to use a [specially modified version of SciGraph](https://github.com/gaurav/SciGraph/tree/public-constructors-and-methods) in order to carry out text annotations.
+
+To install this version locally, run `make SciGraph`. This will download, compile and install the customized SciGraph we use.
+
+You will then need to run `make omnicorp-scigraph` to generate the SciGraph instance for the ontologies specified in ontologies.ofn.
+
 # OmniCORD
 
 Extract ontology terms used in the [COVID-19 Open Research Dataset (CORD)](https://www.semanticscholar.org/cord19) as tab-delimited files for further processing in [COVID-KOP](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7316095/).
 
 In order to generate OmniCORD output files, you should:
-1. Use `robocord.job` to attempt to run all the jobs on a SLURM cluster.
+1. Update the `ROBOCORD_DATE` variable in `Makefile`. You can look up the [latest CORD-19](https://www.semanticscholar.org/cord19/download)
+   release date on their website.
+2. Download the CORD-19 dataset by running `make robocord-download`. This will
+   automatically create a directory in the `robocord-datas` directory and download
+   the CORD-19 dataset for `$ROBOCORD_DATE` into that directory.
+3. Uncompress the dataset by running `make robocord-data`.
+4. Test the extraction program by running `make robocord-test`. This will extract data from some articles
+   in order to ensure that the program is working correctly. It will also create a directory in the
+   `robocord-outputs` directory to store the results in. It's usually a good idea to clear the `robocord-output`
+   directory after running the test and ensuring that the output files look correct.
+5. Use `robocord.job` to attempt to run all the jobs on a SLURM cluster.
    Any number of jobs can be specified, but values of around 4000 seem
    to work with. Example: `sbatch --array=0-3999 robocord.job`.
-2. Use RoboCORDManager to re-run any jobs that failed to complete. You can
+6. Use RoboCORDManager to re-run any jobs that failed to complete. You can
    use the `--dry-run` option to see what jobs will be executed before they
    are run. Jobs are executed using the `robocord-sbatch.sh` script, so
    modify that if necessary.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.4.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version=1.1.1


### PR DESCRIPTION
This PR improves the README for Omnicorp, with instructions for running OmniCORD. I tried recreating these steps on my home laptop and wasn't able to set it up from scratch, but these instructions should be usable in running OmniCORD on the RENCI cluster if need be. I'll figure out why I can't get the code to run on my laptop eventually.