### PR TITLE
Generate TSV file by file

### DIFF
--- a/generate-tsv.job
+++ b/generate-tsv.job
@@ -1,17 +1,21 @@
 #!/bin/bash
 #
 #SBATCH --job-name=OmnicorpTSV
-#SBATCH --output=tsv-output/log-output-%A.txt
-#SBATCH --error=tsv-output/log-error-%A.txt
-#SBATCH --cpus-per-task 32
+#SBATCH --output=tsv-output/omnicorp-tsv-output-%a.txt
+#SBATCH --error=tsv-output/omnicorp-tsv-error-%a.txt
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
 #SBATCH --mem=50000
-#SBATCH --time=12:00:00
+#SBATCH --time=06:00:00
 #SBATCH --mail-user=gaurav@renci.org
 
 set -e # Exit immediately if a pipeline fails.
 
-export JAVA_OPTS="-Xmx50G"
+FILENUM=`printf "%04d" $SLURM_ARRAY_TASK_ID`
+FILENAME="output/pubmed21n$FILENUM.xml.gz.completed.ttl"
 
-echo "Starting GenerateTSV, writing outputs to tsv-output/"
-sbt "runMain org.renci.chemotext.GenerateTSV"
-echo "Processing complete."
+export JAVA_OPTS="-Xmx50G"
+if [ ! -f "${FILENAME}.completed.tsv" ]; then
+  sbt "runMain org.renci.chemotext.GenerateTSV ${FILENAME}"
+fi

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -71,7 +71,7 @@ object GenerateTSV extends App with LazyLogging {
       )
 
       // Check to see if we've already completed processing this file.
-      val completedFilename = new File(outputDir, inputFile.getName + ".tsv")
+      val completedFilename = new File(outputDir, inputFile.getName + ".completed.tsv")
       if (completedFilename.exists) {
         logger.info(s"Skipping, since $completedFilename already exists.")
       } else {

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -33,10 +33,8 @@ object GenerateTSV extends App with LazyLogging {
 
     val files: ScallopOption[List[File]] =
       trailArg[List[File]](descr = "Data file(s) or directories to convert from RDF to TSV")
-    val outputDir: ScallopOption[File] = opt[File](
-      descr = "Directory for output files",
-      default = Some(new File("tsv-output"))
-    )
+    val outputDir: ScallopOption[File] =
+      opt[File](descr = "Directory for output files", default = Some(new File("tsv-output")))
 
     verify()
   }

--- a/src/main/scala/org/renci/chemotext/GenerateTSV.scala
+++ b/src/main/scala/org/renci/chemotext/GenerateTSV.scala
@@ -4,10 +4,12 @@ import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import java.time.Duration
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.{LazyLogging, Logger}
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.vocabulary.{DCTerms, RDF}
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+import org.rogach.scallop.exceptions.ScallopException
 
 /**
   * GenerateTSV generates tab-delimited files summarizing the results of the


### PR DESCRIPTION
Last year, we would generate the output TSV file in one single long-running job. This year, this appears to take a very long time -- I'm not sure why exactly, but since it's pretty easy to modify GenerateTSV to work on each individual file in a separate job, I've made that change. It seems to work.